### PR TITLE
fix(oxiz-solver): add match arm for Distinct constraint

### DIFF
--- a/oxiz-solver/src/solver/encode.rs
+++ b/oxiz-solver/src/solver/encode.rs
@@ -1638,6 +1638,27 @@ impl Solver {
                 self.add_arith_diseq_split_recursive(t, manager, visited);
                 self.add_arith_diseq_split_recursive(e, manager, visited);
             }
+            TermKind::Distinct(args) => {
+                // Generate a Lt/Gt disjunction for each numeric pair, mirroring the
+                // Not(Eq(...)) arm above so the arithmetic solver is aware of the
+                // disequality. `args` borrows from the owned `t` (not from `self` or
+                // `manager`), so no collection is needed before the mutable calls.
+                for (i, &lhs) in args.iter().enumerate() {
+                    let lhs_is_numeric = manager.get(lhs).is_some_and(|lt| {
+                        lt.sort == manager.sorts.int_sort || lt.sort == manager.sorts.real_sort
+                    });
+                    if !lhs_is_numeric {
+                        continue;
+                    }
+                    for &rhs in args[i + 1..].iter() {
+                        let lt_term = manager.mk_lt(lhs, rhs);
+                        let gt_term = manager.mk_gt(lhs, rhs);
+                        let lt_lit = self.encode(lt_term, manager);
+                        let gt_lit = self.encode(gt_term, manager);
+                        self.sat.add_clause([lt_lit, gt_lit]);
+                    }
+                }
+            }
             _ => {}
         }
     }


### PR DESCRIPTION
## Summary

`add_arith_diseq_split_recursive` had no arm for `TermKind::Distinct`, so no `Lt ∨ Gt` split clause was ever generated for `Distinct` terms — the arithmetic solver was therefore never informed of the disequality and could freely assign both sides the same value.

## Changes

- Added a `Distinct` arm that generates the missing `Lt ∨ Gt` clause for each numeric pair, using the same iterator pattern as the existing `Not(Eq(...))` arm.

## Testing

Describe how you tested these changes:
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Doc tests added/updated
- [x] Manual testing performed

## Related Issues

Fixes the first part of #12 (the variant with mk_not(mk_eq) remains broken).

## Checklist

- [x] Code compiles without warnings (`cargo clippy -- -D warnings`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] All tests pass (`cargo nextest run --all-features`)
- [x] Documentation updated if needed
- [x] Commit messages follow the format guidelines