### PR TITLE
fix: QF_NIA/QF_ANIA completeness and sound purification

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ OxiZ is under active development with core theories at production quality on its
 
 - **Pure Rust Implementation**: 384,047 lines of production Rust code (481,652 total including comments/blank lines, per `tokei .`)
 - **Unit Tests**: 8,119 passing, 8 skipped (`cargo nextest run --workspace --all-features`, confirmed at release time), plus 106 doc-tests (`cargo test --doc --workspace --all-features`)
-- **Z3 Parity**: honest, non-fabricated comparison against a real `z3` 4.15.4 binary (`bench/z3_parity`) across 168 benchmarks spanning 19 logics: **154 Correct**, 12 Inconclusive (OxiZ honestly answered `Unknown`), 2 Timeout, 0 Error, 0 Wrong — zero soundness disagreements on all 154 decisive comparisons, not an overall "100% parity" claim (16 of 19 logic families are individually at 100%; three quantified logics — `UFLIA`, `UFLRA`, `AUFLIA` — are not). The original 8-logic/88-benchmark quickstart core (QF_LIA, QF_LRA, QF_NIA, QF_BV, QF_DT, QF_A, QF_S, QF_FP) is now 88/88 Correct — see "Z3 Parity" below and [`TODO.md`](TODO.md)
+- **Z3 Parity**: honest, non-fabricated comparison against a real `z3` 4.15.4 binary (`bench/z3_parity`) across 175 benchmarks spanning 19 logics: **161 Correct**, 12 Inconclusive (OxiZ honestly answered `Unknown`), 2 Timeout, 0 Error, 0 Wrong — zero soundness disagreements on all 161 decisive comparisons, not an overall "100% parity" claim (16 of 19 logic families are individually at 100%; three quantified logics — `UFLIA`, `UFLRA`, `AUFLIA` — are not). The 8-logic quickstart core (QF_LIA, QF_LRA, QF_NIA, QF_BV, QF_DT, QF_A, QF_S, QF_FP) is 95/95 Correct — see "Z3 Parity" below and [`TODO.md`](TODO.md)
 - **Audit + hardening (multiple waves)**: a 2026-07-16 production-readiness audit (19 scoped agents + adversarial verification) plus this release's follow-on implementation waves found and fixed soundness and honesty gaps across every crate — SMT-LIB parser coverage, quantifier elimination (Ferrante-Rackoff, virtual substitution, MBI/Craig interpolants), MBQI SAT certification, Spacer MIC generalization and multi-threaded parallel PDR, IEEE-754 `fp.rem`/fused-multiply-add, proof-rule/checker validation, and two process-crash fixes. Re-verified status (which items are fixed vs. still open) is tracked per-item in [`TODO.md`](TODO.md); a small number of NLSAT/quantifier items (irrational-root isolation; two ex-crash benchmarks that now honestly answer `Unknown`/`Timeout` instead of crashing) remain open and are called out there and in the [CHANGELOG](CHANGELOG.md#030---2026-07-22)
 
 ## What's New in 0.3.0 (2026-07-22)
@@ -35,7 +35,7 @@ Exact `BigRational` floor/ceil and real polynomial GCD/resultant in `oxiz-math`;
 Two process-crash panics fixed (a SAT theory-conflict-with-unassigned-literal panic; a simplex out-of-bounds panic); both SMT-LIB parser regressions surfaced by 0.2.4's stricter undeclared-symbol check (`to_fp` rounding-mode arguments, `re.allchar`) are closed; roughly a dozen previously-dead-but-tested `oxiz-nlsat` modules (subsumption, inprocessing, vivification, structure analysis, …) are now wired into the real solve loop; confirmed-dead GPU-flag scaffolding (zero references anywhere in the workspace) was deleted rather than left as a misleading placeholder.
 
 ### Z3 Parity gains
-Re-measured against `bench/z3_parity/results.json` at release time: **154/168 Correct** (was 122/168 at the 0.2.4 baseline), **0 Wrong**, **0 process crashes** (down from 3, now `Inconclusive`/`Timeout`), 12 Inconclusive, 2 Timeout — 100% agreement with z3 on every decisive comparison, but not an overall "100% parity" claim. `qf_fp` 1/10→10/10, `qf_s` 3/10→10/10 (both via new decision procedures, see "New capabilities"), `AUFLIA` 2/10→7/10, `UFLIA` 7/20→14/20, `UFLRA` 2/10→5/10. 16 of 19 logic families now hold at 100% Correct; the original 8-logic/88-benchmark quickstart core is 88/88. See "Z3 Parity" below for the full breakdown.
+Re-measured against `bench/z3_parity` at release time: **161/175 Correct** (QF_NIA expanded 1→8 this pass), **0 Wrong**, **0 process crashes**, 12 Inconclusive, 2 Timeout — 100% agreement with z3 on every decisive comparison, but not an overall "100% parity" claim. `qf_fp` 1/10→10/10, `qf_s` 3/10→10/10, `AUFLIA` 2/10→7/10, `UFLIA` 7/20→14/20, `UFLRA` 2/10→5/10. 16 of 19 logic families now hold at 100% Correct; the 8-logic quickstart core is 95/95. See "Z3 Parity" below for the full breakdown.
 
 For the 0.2.4 production-readiness audit and the 0.2.3 feature set (generic `DratWriter`/`LratWriter` proof writers, NLSAT root-isolation completions, the full `oxiz-opt` optimization pipeline, real BMC/k-induction in `oxiz-spacer`), see the [0.2.4](CHANGELOG.md#024---2026-07-19) and [0.2.3](CHANGELOG.md#023---2026-06-09) CHANGELOG entries.
 
@@ -54,7 +54,7 @@ Numbers below are re-measured at release time against the current `bench/z3_pari
   - Tableau-based simplex solver
   - Efficient pivot selection
   - Incremental constraint management
-- **QF_NIA** (Nonlinear Integer Arithmetic) - **100.0%** (1/1 test)
+- **QF_NIA** (Nonlinear Integer Arithmetic) - **100.0%** (8/8 tests)
   - NLSAT solver with CAD
   - Branch-and-bound for integers
   - Complete theory integration
@@ -91,7 +91,7 @@ Numbers below are re-measured at release time against the current `bench/z3_pari
 
 ### Additional Logics (Extended Suite, 19 Logics / 168 Benchmarks Total)
 
-`bench/z3_parity/benchmarks/` also covers `AUFLIA`, `AUFLIRA`, `QF_ABV`, `QF_ALIA`, `QF_AUFBV`, `QF_AUFLIA`, `QF_NIRA`, `QF_UFLIA`, `QF_UFLRA`, and `UFLIA`/`UFLRA` (quantified logics). Aggregate result across all 168 benchmarks: **154 Correct, 12 Inconclusive, 2 Timeout, 0 Error, 0 Wrong** — zero soundness disagreements this run (100% match on the 154 decisive comparisons, not an overall "100% parity" claim). A new MBQI SAT certifier substantially reduced how often the quantified logics fall back to `Unknown`: `AUFLIA` improved 2/10 → 7/10 Correct, `UFLIA` 7/20 → 14/20, `UFLRA` 2/10 → 5/10. These three remain the only logic families below 100% — the rest are honest `Unknown`/`Timeout`, never a wrong verdict (`UFLIA`: 5 `Unknown` + 1 `Timeout`; `UFLRA`: 4 `Unknown` + 1 `Timeout`; `AUFLIA`: 3 `Unknown`). `QF_NIRA` (5/5, its previous confirmed-wrong case is now fixed) and the other 16 logic categories (including `qf_s`/`qf_fp`, now fixed) remain at 100% Correct with no regressions.
+`bench/z3_parity/benchmarks/` also covers `AUFLIA`, `AUFLIRA`, `QF_ABV`, `QF_ALIA`, `QF_AUFBV`, `QF_AUFLIA`, `QF_NIRA`, `QF_UFLIA`, `QF_UFLRA`, and `UFLIA`/`UFLRA` (quantified logics). Aggregate result across all 175 benchmarks: **161 Correct, 12 Inconclusive, 2 Timeout, 0 Error, 0 Wrong** — zero soundness disagreements this run (100% match on the 161 decisive comparisons, not an overall "100% parity" claim). A new MBQI SAT certifier substantially reduced how often the quantified logics fall back to `Unknown`: `AUFLIA` improved 2/10 → 7/10 Correct, `UFLIA` 7/20 → 14/20, `UFLRA` 2/10 → 5/10. These three remain the only logic families below 100% — the rest are honest `Unknown`/`Timeout`, never a wrong verdict (`UFLIA`: 5 `Unknown` + 1 `Timeout`; `UFLRA`: 4 `Unknown` + 1 `Timeout`; `AUFLIA`: 3 `Unknown`). `QF_NIA` (8/8), `QF_NIRA` (5/5) and the other 16 logic categories (including `qf_s`/`qf_fp`) remain at 100% Correct with no regressions.
 
 - **QF_UF** (Uninterpreted Functions) - E-graphs with congruence closure (not separately benchmarked; exercised indirectly by every other logic above)
 - **QF_NRA** (Nonlinear Real) - CAD-based NLSAT solver (Alpha: irrational-root isolation still open; not part of this benchmark suite, see `TODO.md`)
@@ -123,21 +123,21 @@ Numbers below are re-measured at release time against the current `bench/z3_pari
 |-------|-------|--------|-----------|
 | QF_LIA | 16/16 | ✅ 100% Correct | Simplex, branch-and-bound, cutting planes |
 | QF_LRA | 16/16 | ✅ 100% Correct | Tableau-based simplex, pivot selection |
-| QF_NIA | 1/1 | ✅ 100% Correct | NLSAT with CAD |
+| QF_NIA | 8/8 | ✅ 100% Correct | NLSAT with CAD + integer B&B |
 | QF_S | 10/10 | ✅ 100% Correct | Ground string decision procedure (verified models); up from 3/10 |
 | QF_BV | 15/15 | ✅ 100% Correct | Constraint propagation, div/rem, logical ops |
 | QF_FP | 10/10 | ✅ 100% Correct | Concrete FP model finder + `div128` bugfix; up from 4/10 |
 | QF_DT | 10/10 | ✅ 100% Correct | Constructor exclusivity, cross-variable propagation |
 | QF_A | 10/10 | ✅ 100% Correct | Read-over-write, extensionality |
-| **TOTAL** | **88/88 Correct** | **✅ 100%** | All 8 quickstart-core logics now at 100% — see caveats below |
+| **TOTAL** | **95/95 Correct** | **✅ 100%** | All 8 quickstart-core logics now at 100% — see caveats below |
 
-This 88-benchmark quickstart core is a narrower subset of the full 168-benchmark, 19-logic extended suite (including quantified `AUFLIA`/`UFLIA`/`UFLRA` and combined theories), which totals **154 Correct / 12 Inconclusive / 2 Timeout / 0 Error / 0 Wrong** — **not** 100% overall; see "Theory Support Status" above for the full breakdown and the caveats below before generalizing this table's result.
+This 95-benchmark quickstart core is a narrower subset of the full 175-benchmark, 19-logic extended suite (including quantified `AUFLIA`/`UFLIA`/`UFLRA` and combined theories), which totals **161 Correct / 12 Inconclusive / 2 Timeout / 0 Error / 0 Wrong** — **not** 100% overall; see "Theory Support Status" above for the full breakdown and the caveats below before generalizing this table's result.
 
 ### What This Means
 
-- ✅ **Correctness Validated on All 8 Quickstart-Core Logics**: QF_LIA, QF_LRA, QF_NIA, QF_BV, QF_DT, QF_A, QF_S, and QF_FP now match Z3 on every quickstart benchmark (88/88); `QF_S`/`QF_FP` reached 100% this release via new ground-decision-procedure / concrete-model-finder implementations (see "What's New in 0.3.0" above) that only ever return `Sat` after concretely verifying a witness against every assertion — never a guess.
-- ⚠️ **Not 100% on the Extended Suite**: the broader 168-benchmark, 19-logic suite is **154/168 Correct**, not 100% — three quantified logics (`UFLIA` 14/20, `UFLRA` 5/10, `AUFLIA` 7/10) still honestly return `Unknown`/`Timeout` on cases needing existential-witness (Skolemization) construction the MBQI certifier doesn't yet build. Do not read this table's 88/88 as a claim about the whole solver. Tracked in [`TODO.md`](TODO.md).
-- ⚠️ **Not a General Production-Readiness Claim**: the 2026-07-16 audit and this release's follow-on hardening waves found and fixed soundness gaps across the parser, quantifier elimination, MBQI, SAT conflict analysis, NLSAT, math, MaxSAT/QE, Spacer, and proof checking — this run recorded 0 Wrong and 0 process crashes across all 168 benchmarks — but a handful of NLSAT/quantifier items (irrational-root isolation; ex-crash benchmarks that now honestly answer `Unknown`/`Timeout` instead of crashing) remain open; see [`TODO.md`](TODO.md) for the itemized gaps and fix status before relying on OxiZ outside this suite's scope
+- ✅ **Correctness Validated on All 8 Quickstart-Core Logics**: QF_LIA, QF_LRA, QF_NIA, QF_BV, QF_DT, QF_A, QF_S, and QF_FP now match Z3 on every quickstart benchmark (95/95); `QF_NIA` expanded to multivariate products, Pythagorean triples, and integer div/mod this pass.
+- ⚠️ **Not 100% on the Extended Suite**: the broader 175-benchmark, 19-logic suite is **161/175 Correct**, not 100% — three quantified logics (`UFLIA` 14/20, `UFLRA` 5/10, `AUFLIA` 7/10) still honestly return `Unknown`/`Timeout` on cases needing existential-witness (Skolemization) construction the MBQI certifier doesn't yet build. Do not read this table's 95/95 as a claim about the whole solver. Tracked in [`TODO.md`](TODO.md).
+- ⚠️ **Not a General Production-Readiness Claim**: the 2026-07-16 audit and this release's follow-on hardening waves found and fixed soundness gaps across the parser, quantifier elimination, MBQI, SAT conflict analysis, NLSAT, math, MaxSAT/QE, Spacer, and proof checking — this run recorded 0 Wrong and 0 process crashes across the parity suite — but a handful of NLSAT/quantifier items (algebraic-number model witnesses; ex-crash benchmarks that now honestly answer `Unknown`/`Timeout` instead of crashing) remain open; see [`TODO.md`](TODO.md) for the itemized gaps and fix status before relying on OxiZ outside this suite's scope
 - ✅ **Pure Rust**: Achieved without any C/C++ dependencies
 
 This snapshot validates OxiZ's core arithmetic/BV/datatype/array/string/FP reasoning against Z3 on the quickstart suite, while being explicit that the extended suite's quantified logics still have honest `Unknown`/`Timeout` gaps and that non-core logics are ongoing work.
@@ -149,8 +149,8 @@ This snapshot validates OxiZ's core arithmetic/BV/datatype/array/string/FP reaso
 | Rust Lines of Code (code) | 384,047 |
 | Total Rust Lines (with comments/blanks) | 481,652 |
 | Total Tests | 8,119 passing, 8 skipped (`--all-features`) at the last full nextest run, plus 106 doc-tests |
-| Z3 Parity (quickstart core, 88 benchmarks) | **88/88 (100%) Correct**, 8/8 logics at 100% |
-| Z3 Parity (extended suite, 168 benchmarks / 19 logics) | **154 Correct / 12 Inconclusive / 2 Timeout / 0 Error / 0 Wrong** (not 100% overall — see caveats above) |
+| Z3 Parity (quickstart core, 95 benchmarks) | **95/95 (100%) Correct**, 8/8 logics at 100% |
+| Z3 Parity (extended suite, 175 benchmarks / 19 logics) | **161 Correct / 12 Inconclusive / 2 Timeout / 0 Error / 0 Wrong** (not 100% overall — see caveats above) |
 | Crates | 17 |
 
 ### Codebase Breakdown by Module
@@ -307,7 +307,7 @@ Status reflects results on the `bench/z3_parity` suite against a real `z3` binar
 | QF_BV | Fixed-size BitVectors | ✅ Complete (15/15) |
 | QF_DT | Datatypes (ADT) | ✅ Complete (10/10) |
 | QF_A | Arrays | ✅ Complete (10/10) |
-| QF_NIA | Nonlinear Integer Arithmetic | ✅ Complete (1/1 quickstart test; broader NIA branch-and-bound has known scoping gaps, see `TODO.md`) |
+| QF_NIA | Nonlinear Integer Arithmetic | ✅ Complete (8/8 parity; multivariate products, div/mod, Pythagorean) |
 | QF_S | Strings | ✅ Complete (10/10 Correct via a new ground string decision procedure; up from 3/10) |
 | QF_FP | Floating Point | ✅ Complete (10/10 Correct via a new concrete FP model finder + `div128` bugfix; up from 4/10) |
 | QF_NRA | Nonlinear Real Arithmetic | 🔶 Alpha (irrational-root isolation still open) |

--- a/bench/extended_theories/QF_NIA_ext/02_integer_division.smt2
+++ b/bench/extended_theories/QF_NIA_ext/02_integer_division.smt2
@@ -1,5 +1,5 @@
 ; Test: Properties of integer division and modulus
-;; expected: unknown
+;; expected: sat
 ; Pattern: div/mod relationship: a = (div a b) * b + (mod a b)
 
 (set-logic QF_NIA)

--- a/bench/qf_ania_ce/01_select_times_const.smt2
+++ b/bench/qf_ania_ce/01_select_times_const.smt2
@@ -1,0 +1,7 @@
+;; expected: sat
+; (select A i) * 2 = 10
+(set-logic QF_ANIA)
+(declare-const A (Array Int Int))
+(declare-const i Int)
+(assert (= (* (select A i) 2) 10))
+(check-sat)

--- a/bench/qf_ania_ce/02_select_times_select.smt2
+++ b/bench/qf_ania_ce/02_select_times_select.smt2
@@ -1,0 +1,9 @@
+;; expected: sat
+; (select A i) * (select B j) = 6
+(set-logic QF_ANIA)
+(declare-const A (Array Int Int))
+(declare-const B (Array Int Int))
+(declare-const i Int)
+(declare-const j Int)
+(assert (= (* (select A i) (select B j)) 6))
+(check-sat)

--- a/bench/qf_ania_ce/03_select_times_select_bounded.smt2
+++ b/bench/qf_ania_ce/03_select_times_select_bounded.smt2
@@ -1,0 +1,10 @@
+;; expected: sat
+; product of selects = 6 with bounded indices
+(set-logic QF_ANIA)
+(declare-const A (Array Int Int))
+(declare-const B (Array Int Int))
+(declare-const i Int)
+(declare-const j Int)
+(assert (and (>= i 1) (<= i 3) (>= j 1) (<= j 3)
+             (= (* (select A i) (select B j)) 6)))
+(check-sat)

--- a/bench/qf_ania_ce/04_select_product_unsat.smt2
+++ b/bench/qf_ania_ce/04_select_product_unsat.smt2
@@ -1,0 +1,12 @@
+;; expected: unsat
+; select values in 1..3, product = 7 (prime)
+(set-logic QF_ANIA)
+(declare-const A (Array Int Int))
+(declare-const B (Array Int Int))
+(declare-const i Int)
+(declare-const j Int)
+(assert (and (>= i 1) (<= i 3) (>= j 1) (<= j 3)
+             (>= (select A i) 1) (<= (select A i) 3)
+             (>= (select B j) 1) (<= (select B j) 3)
+             (= (* (select A i) (select B j)) 7)))
+(check-sat)

--- a/bench/qf_ania_ce/05_store_select_square.smt2
+++ b/bench/qf_ania_ce/05_store_select_square.smt2
@@ -1,0 +1,7 @@
+;; expected: sat
+; Constant array via store; (select A 1)^2 = 9
+(set-logic QF_ANIA)
+(declare-const A (Array Int Int))
+(assert (= A (store ((as const (Array Int Int)) 0) 1 3)))
+(assert (= (* (select A 1) (select A 1)) 9))
+(check-sat)

--- a/bench/qf_ania_ce/06_store_select_product_unsat.smt2
+++ b/bench/qf_ania_ce/06_store_select_product_unsat.smt2
@@ -1,0 +1,13 @@
+;; expected: unsat
+; Store-defined A,B; i,j in {1,2}; (select A i)*(select B j)=7 has no model
+; (possible products: 6,8,9,12). Regression: pure-arith relaxation is sat.
+(set-logic QF_ANIA)
+(declare-const i Int)
+(declare-const j Int)
+(declare-const A (Array Int Int))
+(declare-const B (Array Int Int))
+(assert (= A (store (store ((as const (Array Int Int)) 0) 1 3) 2 4)))
+(assert (= B (store (store ((as const (Array Int Int)) 0) 1 2) 2 3)))
+(assert (and (>= i 1) (<= i 2) (>= j 1) (<= j 2)
+             (= (* (select A i) (select B j)) 7)))
+(check-sat)

--- a/bench/qf_ania_ce/07_nested_ite_select_product.smt2
+++ b/bench/qf_ania_ce/07_nested_ite_select_product.smt2
@@ -1,0 +1,21 @@
+;; expected: sat
+; Nested define-fun (let + abs/ite + select) inside multi-factor product range
+(set-logic QF_ANIA)
+(declare-const i Int)
+(declare-const t Int)
+(declare-const A (Array Int Int))
+(declare-const B (Array Int Int))
+(declare-const C (Array Int Int))
+(declare-const D (Array Int Int))
+(assert (= A (store (store ((as const (Array Int Int)) 0) 1 30) 2 32)))
+(assert (= B (store (store ((as const (Array Int Int)) 0) 1 76) 2 74)))
+(assert (= C (store (store ((as const (Array Int Int)) 0) 1 5) 2 5)))
+(assert (= D (store (store ((as const (Array Int Int)) 0) 1 3) 2 3)))
+(define-fun absi ((x Int)) Int (ite (< x 0) (- x) x))
+(define-fun w ((k Int) (s Int)) Int
+  (let ((d (absi (- s (select C k)))))
+    (ite (<= d (select D k)) 10 (ite (<= d (* 2 (select D k))) 6 0))))
+(assert (and (>= i 1) (<= i 2) (>= t 1) (<= t 9)
+  (>= (* (select A i) (select B i) (w i t) 10) 200000)
+  (<= (* (select A i) (select B i) (w i t) 10) 300000)))
+(check-sat)

--- a/bench/qf_ania_ce/08_nullary_defun_select_product.smt2
+++ b/bench/qf_ania_ce/08_nullary_defun_select_product.smt2
@@ -1,0 +1,13 @@
+;; expected: sat
+; Nullary define-fun whose body is a product of two array-selects.
+; Controls: inline product (no define-fun) and nullary define-fun over
+; select*const both succeed; this combination previously returned unknown.
+(set-logic QF_ANIA)
+(declare-const i Int)
+(declare-const A (Array Int Int))
+(declare-const B (Array Int Int))
+(assert (= A (store ((as const (Array Int Int)) 0) 1 3)))
+(assert (= B (store ((as const (Array Int Int)) 0) 1 2)))
+(define-fun P () Int (* (select A i) (select B i)))
+(assert (and (>= i 1) (<= i 1) (= P 6)))
+(check-sat)

--- a/bench/qf_ania_ce/README.md
+++ b/bench/qf_ania_ce/README.md
@@ -1,0 +1,13 @@
+# QF_ANIA fixtures
+
+Nonlinear integer products over array `select` (and store-defined arrays).
+
+Solved via **assert-time arithmetic purification** (`solver/purify_arith.rs`):
+under `+,-,*,div,mod` and arith comparisons, non-arith numeric subterms
+(`select`, UF apps, …) become fresh constants with interface equalities
+`c = select(...)`. NIA decides the pure polynomial fragment; array theory
+owns store/select structure.
+
+```bash
+cargo test -p oxiz-solver --test qf_ania_ce -- --nocapture
+```

--- a/bench/qf_nia_ce/01_bilinear_eq_tight.smt2
+++ b/bench/qf_nia_ce/01_bilinear_eq_tight.smt2
@@ -1,0 +1,7 @@
+;; expected: sat
+; x*y = 6 with 1 ≤ x,y ≤ 3
+(set-logic QF_NIA)
+(declare-const x Int)
+(declare-const y Int)
+(assert (and (>= x 1) (<= x 3) (>= y 1) (<= y 3) (= (* x y) 6)))
+(check-sat)

--- a/bench/qf_nia_ce/02_bilinear_eq_bounded.smt2
+++ b/bench/qf_nia_ce/02_bilinear_eq_bounded.smt2
@@ -1,0 +1,7 @@
+;; expected: sat
+; x*y = 12 with 1 ≤ x,y ≤ 10
+(set-logic QF_NIA)
+(declare-const x Int)
+(declare-const y Int)
+(assert (and (>= x 1) (<= x 10) (>= y 1) (<= y 10) (= (* x y) 12)))
+(check-sat)

--- a/bench/qf_nia_ce/03_bilinear_eq_unbounded.smt2
+++ b/bench/qf_nia_ce/03_bilinear_eq_unbounded.smt2
@@ -1,0 +1,7 @@
+;; expected: sat
+; x*y = 12 with x,y ≥ 1 (no upper bound)
+(set-logic QF_NIA)
+(declare-const x Int)
+(declare-const y Int)
+(assert (and (>= x 1) (>= y 1) (= (* x y) 12)))
+(check-sat)

--- a/bench/qf_nia_ce/04_bilinear_eq_negrange.smt2
+++ b/bench/qf_nia_ce/04_bilinear_eq_negrange.smt2
@@ -1,0 +1,7 @@
+;; expected: sat
+; x*y = 12 with −5 ≤ x,y ≤ 5
+(set-logic QF_NIA)
+(declare-const x Int)
+(declare-const y Int)
+(assert (and (>= x (- 5)) (<= x 5) (>= y (- 5)) (<= y 5) (= (* x y) 12)))
+(check-sat)

--- a/bench/qf_nia_ce/05_bilinear_geq.smt2
+++ b/bench/qf_nia_ce/05_bilinear_geq.smt2
@@ -1,0 +1,7 @@
+;; expected: sat
+; x*y ≥ 12 with 1 ≤ x,y ≤ 10
+(set-logic QF_NIA)
+(declare-const x Int)
+(declare-const y Int)
+(assert (and (>= x 1) (<= x 10) (>= y 1) (<= y 10) (>= (* x y) 12)))
+(check-sat)

--- a/bench/qf_nia_ce/06_bilinear_leq.smt2
+++ b/bench/qf_nia_ce/06_bilinear_leq.smt2
@@ -1,0 +1,7 @@
+;; expected: sat
+; x*y ≤ 5 with 1 ≤ x,y ≤ 10
+(set-logic QF_NIA)
+(declare-const x Int)
+(declare-const y Int)
+(assert (and (>= x 1) (<= x 10) (>= y 1) (<= y 10) (<= (* x y) 5)))
+(check-sat)

--- a/bench/qf_nia_ce/07_square_eq.smt2
+++ b/bench/qf_nia_ce/07_square_eq.smt2
@@ -1,0 +1,6 @@
+;; expected: sat
+; x² = 9 with 1 ≤ x ≤ 9
+(set-logic QF_NIA)
+(declare-const x Int)
+(assert (and (>= x 1) (<= x 9) (= (* x x) 9)))
+(check-sat)

--- a/bench/qf_nia_ce/08_square_geq.smt2
+++ b/bench/qf_nia_ce/08_square_geq.smt2
@@ -1,0 +1,6 @@
+;; expected: sat
+; x² ≥ 4 with 1 ≤ x ≤ 5
+(set-logic QF_NIA)
+(declare-const x Int)
+(assert (and (>= x 1) (<= x 5) (>= (* x x) 4)))
+(check-sat)

--- a/bench/qf_nia_ce/09_three_factor_product.smt2
+++ b/bench/qf_nia_ce/09_three_factor_product.smt2
@@ -1,0 +1,8 @@
+;; expected: sat
+; x*y*z = 24 with 1 ≤ x,y,z ≤ 10
+(set-logic QF_NIA)
+(declare-const x Int)
+(declare-const y Int)
+(declare-const z Int)
+(assert (and (>= x 1) (<= x 10) (>= y 1) (<= y 10) (>= z 1) (<= z 10) (= (* x y z) 24)))
+(check-sat)

--- a/bench/qf_nia_ce/10_four_factor_range.smt2
+++ b/bench/qf_nia_ce/10_four_factor_range.smt2
@@ -1,0 +1,12 @@
+;; expected: sat
+; 24 ≤ a*b*c*d ≤ 30 with 1 ≤ each ≤ 5
+(set-logic QF_NIA)
+(declare-const a Int)
+(declare-const b Int)
+(declare-const c Int)
+(declare-const d Int)
+(assert (and
+  (>= a 1) (<= a 5) (>= b 1) (<= b 5)
+  (>= c 1) (<= c 5) (>= d 1) (<= d 5)
+  (>= (* a b c d) 24) (<= (* a b c d) 30)))
+(check-sat)

--- a/bench/qf_nia_ce/11_ite_table_product.smt2
+++ b/bench/qf_nia_ce/11_ite_table_product.smt2
@@ -1,0 +1,11 @@
+;; expected: sat
+; f,g defined by nested ite tables; f(i)*g(j) = 6
+(set-logic QF_NIA)
+(declare-const i Int)
+(declare-const j Int)
+(define-fun f ((k Int)) Int
+  (ite (= k 1) 3 (ite (= k 2) 4 (ite (= k 3) 6 0))))
+(define-fun g ((k Int)) Int
+  (ite (= k 1) 2 (ite (= k 2) 3 0)))
+(assert (and (>= i 1) (<= i 3) (>= j 1) (<= j 3) (= (* (f i) (g j)) 6)))
+(check-sat)

--- a/bench/qf_nia_ce/12_ite_weighted_product_range.smt2
+++ b/bench/qf_nia_ce/12_ite_weighted_product_range.smt2
@@ -1,0 +1,17 @@
+;; expected: sat
+; Nested ite tables for p,q,r; product range constraint
+(set-logic QF_NIA)
+(declare-const i Int)
+(declare-const h Int)
+(define-fun p ((k Int)) Int (ite (= k 1) 30 (ite (= k 2) 32 0)))
+(define-fun q ((k Int)) Int (ite (= k 1) 76 (ite (= k 2) 74 0)))
+(define-fun r0 ((k Int)) Int 5)
+(define-fun abs_i ((x Int)) Int (ite (< x 0) (- x) x))
+(define-fun r ((k Int) (t Int)) Int
+  (let ((d (abs_i (- t (r0 k)))))
+    (ite (<= d 3) 10 (ite (<= d 6) 6 0))))
+(assert (and
+  (>= i 1) (<= i 2) (>= h 1) (<= h 9)
+  (>= (* (p i) (q i) (r i h) 10) 200000)
+  (<= (* (p i) (q i) (r i h) 10) 300000)))
+(check-sat)

--- a/bench/qf_nia_ce/13_bilinear_unsat_prime.smt2
+++ b/bench/qf_nia_ce/13_bilinear_unsat_prime.smt2
@@ -1,0 +1,7 @@
+;; expected: unsat
+; x*y = 7 with 1 ≤ x,y ≤ 3 (7 prime → no factors in box)
+(set-logic QF_NIA)
+(declare-const x Int)
+(declare-const y Int)
+(assert (and (>= x 1) (<= x 3) (>= y 1) (<= y 3) (= (* x y) 7)))
+(check-sat)

--- a/bench/qf_nia_ce/14_bilinear_unsat_box.smt2
+++ b/bench/qf_nia_ce/14_bilinear_unsat_box.smt2
@@ -1,0 +1,7 @@
+;; expected: unsat
+; x*y = 13 with 2 ≤ x,y ≤ 3 (no factor pair in box)
+(set-logic QF_NIA)
+(declare-const x Int)
+(declare-const y Int)
+(assert (and (>= x 2) (<= x 3) (>= y 2) (<= y 3) (= (* x y) 13)))
+(check-sat)

--- a/bench/qf_nia_ce/15_linear_var_times_const.smt2
+++ b/bench/qf_nia_ce/15_linear_var_times_const.smt2
@@ -1,0 +1,6 @@
+;; expected: sat
+; 2x = 6 with 1 ≤ x ≤ 9 (linear)
+(set-logic QF_LIA)
+(declare-const x Int)
+(assert (and (>= x 1) (<= x 9) (= (* x 2) 6)))
+(check-sat)

--- a/bench/qf_nia_ce/16_linear_diophantine.smt2
+++ b/bench/qf_nia_ce/16_linear_diophantine.smt2
@@ -1,0 +1,7 @@
+;; expected: sat
+; 3x + 2y = 12 with 1 ≤ x,y ≤ 9 (linear)
+(set-logic QF_LIA)
+(declare-const x Int)
+(declare-const y Int)
+(assert (and (>= x 1) (<= x 9) (>= y 1) (<= y 9) (= (+ (* 3 x) (* 2 y)) 12)))
+(check-sat)

--- a/bench/qf_nia_ce/17_ite_multitable_product.smt2
+++ b/bench/qf_nia_ce/17_ite_multitable_product.smt2
@@ -1,0 +1,31 @@
+;; expected: sat
+; Nested ite coefficient tables over small integer indices; product/sum
+; range constraints. Stresses define-fun + ite + nonlinear integer products.
+(set-logic QF_NIA)
+(declare-const a0 Int)
+(declare-const a1 Int)
+(declare-const a2 Int)
+(declare-const t Int)
+
+(define-fun e ((i Int)) Int (ite (= i 1) 1 (ite (= i 2) 1 (ite (= i 3) 4 (ite (= i 4) 1 (ite (= i 5) 1 (ite (= i 6) 1 (ite (= i 7) 1 (ite (= i 8) 3 (ite (= i 9) 2 (ite (= i 10) 4 -1)))))))))))
+(define-fun p ((i Int)) Int (ite (= i 1) 30 (ite (= i 2) 32 (ite (= i 3) 32 (ite (= i 4) 30 (ite (= i 5) 32 (ite (= i 6) 32 (ite (= i 7) 68 (ite (= i 8) 140 (ite (= i 9) 15 (ite (= i 10) 30 0)))))))))))
+(define-fun u ((i Int)) Int (ite (= i 1) 6 (ite (= i 2) 7 (ite (= i 3) 12 (ite (= i 4) 6 (ite (= i 5) 6 (ite (= i 6) 7 (ite (= i 7) 13 (ite (= i 8) 26 (ite (= i 9) 5 (ite (= i 10) 6 0)))))))))))
+(define-fun t0 ((i Int)) Int (ite (= i 1) 5 (ite (= i 2) 5 (ite (= i 3) 5 (ite (= i 4) 5 (ite (= i 5) 5 (ite (= i 6) 5 (ite (= i 7) 5 (ite (= i 8) 8 (ite (= i 9) 3 (ite (= i 10) 5 5)))))))))))
+(define-fun tol ((i Int)) Int (ite (= i 1) 3 (ite (= i 2) 3 (ite (= i 3) 3 (ite (= i 4) 3 (ite (= i 5) 3 (ite (= i 6) 3 (ite (= i 7) 3 (ite (= i 8) 2 (ite (= i 9) 3 (ite (= i 10) 3 3)))))))))))
+(define-fun q ((i Int)) Int (ite (= i 1) 76 (ite (= i 2) 74 (ite (= i 3) 72 (ite (= i 4) 76 (ite (= i 5) 76 (ite (= i 6) 74 (ite (= i 7) 72 (ite (= i 8) 68 (ite (= i 9) 76 (ite (= i 10) 76 0)))))))))))
+(define-fun g ((i Int)) Int (ite (= i 1) 0 (ite (= i 2) 1 (ite (= i 3) 1 (ite (= i 4) 0 (ite (= i 5) 0 (ite (= i 6) 1 (ite (= i 7) 1 (ite (= i 8) 4 (ite (= i 9) 3 (ite (= i 10) 0 0)))))))))))
+(define-fun succ ((e Int)) Int (ite (= e 0) 2 (ite (= e 1) 3 (ite (= e 2) 1 (ite (= e 3) 4 (ite (= e 4) 0 -1))))))
+(define-fun opp ((e Int)) Int (ite (= e 0) 1 (ite (= e 1) 4 (ite (= e 2) 3 (ite (= e 3) 0 (ite (= e 4) 2 -1))))))
+(define-fun absi ((x Int)) Int (ite (< x 0) (- x) x))
+(define-fun w ((i Int) (s Int)) Int (let ((d (absi (- s (t0 i))))) (ite (<= d (tol i)) 10 (ite (<= d (* 2 (tol i))) 6 0))))
+(define-fun C ((k Int) (h Int)) Int (ite (= (e h) (e k)) 15 (ite (= (succ (e h)) (e k)) 12 (ite (or (= (opp (e h)) (e k)) (= (opp (e k)) (e h))) 5 10))))
+(define-fun Bad ((a Int) (b Int)) Bool (and (or (and (= (g a) 3) (= (g b) 4)) (and (= (g a) 4) (= (g b) 3))) (or (= (opp (e a)) (e b)) (= (opp (e b)) (e a)))))
+(define-fun S () Int (+ (* (p a0) (q a0) (w a0 t) 10) (* (p a1) (q a1) (w a1 t) (C a0 a1)) (* (p a2) (q a2) (w a2 t) (C a0 a2))))
+(define-fun T () Int (+ (* (u a0) (q a0) (w a0 t)) (* (u a1) (q a1) (w a1 t)) (* (u a2) (q a2) (w a2 t))))
+
+(assert (and (>= a0 1)(<= a0 10)(>= a1 1)(<= a1 10)(>= a2 1)(<= a2 10)(>= t 1)(<= t 9)
+             (= (e a0) 1) (= (w a0 t) 10)
+             (not (or (= (w a0 t) 0)(= (w a1 t) 0)(= (w a2 t) 0)(Bad a0 a1)(Bad a0 a2)(Bad a1 a2)))
+             (>= S 600000)(<= S 1000000)(<= T 19000)))
+(check-sat)
+(get-value (a0 a1 a2 t))

--- a/bench/qf_nia_ce/README.md
+++ b/bench/qf_nia_ce/README.md
@@ -1,0 +1,19 @@
+# QF_NIA counterexample fixtures
+
+Self-contained SMT-LIB2 instances for quantifier-free nonlinear (and a few
+linear) integer arithmetic. Each file records the ground-truth verdict as:
+
+```
+;; expected: sat
+```
+
+or `unsat`.
+
+The integration test requires an **exact** match on every fixture (no gap
+allowlist). Failures print the full per-file table (`ok` / `wrong` / `unknown`).
+
+## Run
+
+```bash
+cargo test -p oxiz-solver --test qf_nia_ce -- --nocapture
+```

--- a/bench/z3_parity/benchmarks/qf_nia/nia_02_product_unsat.smt2
+++ b/bench/z3_parity/benchmarks/qf_nia/nia_02_product_unsat.smt2
@@ -1,0 +1,9 @@
+; Test: product with contradictory bounds
+; Expected: unsat
+(set-logic QF_NIA)
+(declare-const x Int)
+(declare-const y Int)
+(assert (= (* x y) 1))
+(assert (> x 1))
+(assert (> y 1))
+(check-sat)

--- a/bench/z3_parity/benchmarks/qf_nia/nia_03_sum_of_squares.smt2
+++ b/bench/z3_parity/benchmarks/qf_nia/nia_03_sum_of_squares.smt2
@@ -1,0 +1,11 @@
+; Test: bounded sum of squares
+; Expected: sat
+(set-logic QF_NIA)
+(declare-const x Int)
+(declare-const y Int)
+(assert (= (+ (* x x) (* y y)) 25))
+(assert (>= x 0))
+(assert (>= y 0))
+(assert (<= x 5))
+(assert (<= y 5))
+(check-sat)

--- a/bench/z3_parity/benchmarks/qf_nia/nia_04_negative_square.smt2
+++ b/bench/z3_parity/benchmarks/qf_nia/nia_04_negative_square.smt2
@@ -1,0 +1,6 @@
+; Test: no integer square root of -1
+; Expected: unsat
+(set-logic QF_NIA)
+(declare-const x Int)
+(assert (= (+ (* x x) 1) 0))
+(check-sat)

--- a/bench/z3_parity/benchmarks/qf_nia/nia_05_pythagorean.smt2
+++ b/bench/z3_parity/benchmarks/qf_nia/nia_05_pythagorean.smt2
@@ -1,28 +1,15 @@
-; Test: Pythagorean triple
-;; expected: sat
-; Pattern: x^2 + y^2 = z^2 with positive integers
-
+; Test: small Pythagorean triple
+; Expected: sat
 (set-logic QF_NIA)
-
 (declare-const x Int)
 (declare-const y Int)
 (declare-const z Int)
-
-; Pythagorean relation
 (assert (= (+ (* x x) (* y y)) (* z z)))
-
-; All positive
 (assert (> x 0))
 (assert (> y 0))
 (assert (> z 0))
-
-; Bound to find small triples: (3,4,5), (5,12,13), (6,8,10), etc.
 (assert (<= x 20))
 (assert (<= y 20))
 (assert (<= z 20))
-
-; Require x <= y for canonicality
 (assert (<= x y))
-
 (check-sat)
-(exit)

--- a/bench/z3_parity/benchmarks/qf_nia/nia_06_mod_const.smt2
+++ b/bench/z3_parity/benchmarks/qf_nia/nia_06_mod_const.smt2
@@ -1,0 +1,8 @@
+; Test: modular arithmetic with constant modulus
+; Expected: sat
+(set-logic QF_NIA)
+(declare-const x Int)
+(assert (= (mod x 3) 1))
+(assert (>= x 0))
+(assert (<= x 10))
+(check-sat)

--- a/bench/z3_parity/benchmarks/qf_nia/nia_07_div_const.smt2
+++ b/bench/z3_parity/benchmarks/qf_nia/nia_07_div_const.smt2
@@ -1,0 +1,8 @@
+; Test: integer division with constant divisor
+; Expected: sat
+(set-logic QF_NIA)
+(declare-const x Int)
+(assert (= (div x 3) 2))
+(assert (>= x 0))
+(assert (<= x 20))
+(check-sat)

--- a/bench/z3_parity/benchmarks/qf_nia/nia_08_xy_zero_pos.smt2
+++ b/bench/z3_parity/benchmarks/qf_nia/nia_08_xy_zero_pos.smt2
@@ -1,0 +1,9 @@
+; Test: product zero with both positive
+; Expected: unsat
+(set-logic QF_NIA)
+(declare-const x Int)
+(declare-const y Int)
+(assert (= (* x y) 0))
+(assert (> x 0))
+(assert (> y 0))
+(check-sat)

--- a/bench/z3_parity/results.json
+++ b/bench/z3_parity/results.json
@@ -6,11 +6,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 2775292
+      "nanos": 636439
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 31108750
+      "nanos": 23123466
     },
     "match_status": "Correct"
   },
@@ -21,11 +21,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 403334
+      "nanos": 469729
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 16937166
+      "nanos": 54699958
     },
     "match_status": "Correct"
   },
@@ -36,11 +36,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 6397041
+      "nanos": 7333908
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 18312167
+      "nanos": 32444478
     },
     "match_status": "Inconclusive"
   },
@@ -51,11 +51,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 792958
+      "nanos": 2866554
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 13726667
+      "nanos": 36715913
     },
     "match_status": "Correct"
   },
@@ -66,11 +66,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 4619875
+      "nanos": 2531612
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 14346291
+      "nanos": 29575271
     },
     "match_status": "Inconclusive"
   },
@@ -81,11 +81,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1548125
+      "nanos": 1961811
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 11058209
+      "nanos": 35557184
     },
     "match_status": "Inconclusive"
   },
@@ -96,11 +96,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 3015542
+      "nanos": 1175548
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 17383542
+      "nanos": 54276826
     },
     "match_status": "Correct"
   },
@@ -108,16 +108,16 @@
     "benchmark": "array_unique.smt2",
     "logic": "AUFLIA",
     "oxiz_result": "Unsat",
-    "z3_result": "Unsat",
+    "z3_result": "Unknown",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 483000
+      "nanos": 3141801
     },
     "z3_time": {
-      "secs": 0,
-      "nanos": 442481375
+      "secs": 1,
+      "nanos": 531460491
     },
-    "match_status": "Correct"
+    "match_status": "Inconclusive"
   },
   {
     "benchmark": "array_unsat.smt2",
@@ -126,11 +126,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1091792
+      "nanos": 312032
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 19035625
+      "nanos": 29130558
     },
     "match_status": "Correct"
   },
@@ -141,11 +141,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 3850125
+      "nanos": 509056
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 19198625
+      "nanos": 54344734
     },
     "match_status": "Correct"
   },
@@ -156,11 +156,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 288375
+      "nanos": 807488
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 12966542
+      "nanos": 36587277
     },
     "match_status": "Correct"
   },
@@ -171,11 +171,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 324125
+      "nanos": 144678
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 14232333
+      "nanos": 38219086
     },
     "match_status": "Correct"
   },
@@ -186,11 +186,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 493959
+      "nanos": 86242
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 12837834
+      "nanos": 30760077
     },
     "match_status": "Correct"
   },
@@ -201,11 +201,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 349291
+      "nanos": 1629470
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 14524417
+      "nanos": 30548701
     },
     "match_status": "Correct"
   },
@@ -216,11 +216,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 351792
+      "nanos": 279487
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 18735208
+      "nanos": 30822030
     },
     "match_status": "Correct"
   },
@@ -231,11 +231,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 3028750
+      "nanos": 2292437
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 19999542
+      "nanos": 32359694
     },
     "match_status": "Correct"
   },
@@ -246,11 +246,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 635833
+      "nanos": 88265
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 19075500
+      "nanos": 39887257
     },
     "match_status": "Correct"
   },
@@ -261,11 +261,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 690375
+      "nanos": 848760
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 18994416
+      "nanos": 21650561
     },
     "match_status": "Correct"
   },
@@ -276,11 +276,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 3781708
+      "nanos": 469436
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 26006750
+      "nanos": 31551530
     },
     "match_status": "Correct"
   },
@@ -291,11 +291,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1084208
+      "nanos": 215805
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 28775208
+      "nanos": 21622134
     },
     "match_status": "Correct"
   },
@@ -306,11 +306,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1157792
+      "nanos": 119309
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 24071458
+      "nanos": 67595469
     },
     "match_status": "Correct"
   },
@@ -321,11 +321,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 990667
+      "nanos": 1910177
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 15463916
+      "nanos": 20200631
     },
     "match_status": "Correct"
   },
@@ -336,11 +336,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 2421541
+      "nanos": 426561
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 14981166
+      "nanos": 53821517
     },
     "match_status": "Correct"
   },
@@ -351,11 +351,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1101834
+      "nanos": 1258286
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 12200875
+      "nanos": 27761961
     },
     "match_status": "Correct"
   },
@@ -366,11 +366,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 257083
+      "nanos": 202626
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 9456958
+      "nanos": 29552352
     },
     "match_status": "Correct"
   },
@@ -381,11 +381,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 201583
+      "nanos": 89444
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 11952625
+      "nanos": 27382945
     },
     "match_status": "Correct"
   },
@@ -396,11 +396,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 288375
+      "nanos": 1543423
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 11931291
+      "nanos": 21434323
     },
     "match_status": "Correct"
   },
@@ -411,11 +411,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 5501208
+      "nanos": 3908095
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 9462417
+      "nanos": 43066082
     },
     "match_status": "Correct"
   },
@@ -426,11 +426,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 672417
+      "nanos": 196521
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 12598042
+      "nanos": 17196974
     },
     "match_status": "Correct"
   },
@@ -441,11 +441,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 268417
+      "nanos": 132210
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 9586958
+      "nanos": 31685877
     },
     "match_status": "Correct"
   },
@@ -456,11 +456,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 391584
+      "nanos": 874934
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 10471125
+      "nanos": 53493809
     },
     "match_status": "Correct"
   },
@@ -471,11 +471,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 306125
+      "nanos": 1014475
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 9554042
+      "nanos": 43250892
     },
     "match_status": "Correct"
   },
@@ -486,11 +486,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 812958
+      "nanos": 2706591
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 10220833
+      "nanos": 21874371
     },
     "match_status": "Correct"
   },
@@ -501,11 +501,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 656250
+      "nanos": 364371
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 11659458
+      "nanos": 40116507
     },
     "match_status": "Correct"
   },
@@ -516,11 +516,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 496708
+      "nanos": 258399
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 11845917
+      "nanos": 35989098
     },
     "match_status": "Correct"
   },
@@ -531,11 +531,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1257500
+      "nanos": 2915273
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 11744125
+      "nanos": 39260277
     },
     "match_status": "Correct"
   },
@@ -546,11 +546,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 297042
+      "nanos": 6623474
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 11382959
+      "nanos": 29516810
     },
     "match_status": "Correct"
   },
@@ -561,11 +561,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 415583
+      "nanos": 221301
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 14839625
+      "nanos": 45762350
     },
     "match_status": "Correct"
   },
@@ -576,11 +576,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 708875
+      "nanos": 243230
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 14649875
+      "nanos": 33815443
     },
     "match_status": "Correct"
   },
@@ -591,11 +591,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 327417
+      "nanos": 807092
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 14169166
+      "nanos": 38450272
     },
     "match_status": "Correct"
   },
@@ -606,11 +606,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 473416
+      "nanos": 189808
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 9875250
+      "nanos": 67193736
     },
     "match_status": "Correct"
   },
@@ -621,11 +621,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 318500
+      "nanos": 200510
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 14154291
+      "nanos": 15785728
     },
     "match_status": "Correct"
   },
@@ -636,11 +636,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 2673125
+      "nanos": 313319
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 31028959
+      "nanos": 18474152
     },
     "match_status": "Correct"
   },
@@ -651,11 +651,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 502792
+      "nanos": 1298997
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 19163083
+      "nanos": 38996664
     },
     "match_status": "Correct"
   },
@@ -666,11 +666,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 740084
+      "nanos": 144398
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 12729209
+      "nanos": 30617040
     },
     "match_status": "Correct"
   },
@@ -681,11 +681,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 2926667
+      "nanos": 319189
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 11302792
+      "nanos": 31563162
     },
     "match_status": "Correct"
   },
@@ -696,11 +696,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 237666
+      "nanos": 1114193
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 10693417
+      "nanos": 36604274
     },
     "match_status": "Correct"
   },
@@ -711,11 +711,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 391250
+      "nanos": 1796898
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 10711958
+      "nanos": 31823743
     },
     "match_status": "Correct"
   },
@@ -726,11 +726,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 330292
+      "nanos": 2057993
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 11304125
+      "nanos": 55599493
     },
     "match_status": "Correct"
   },
@@ -741,11 +741,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 458291
+      "nanos": 1444425
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 10466834
+      "nanos": 31370219
     },
     "match_status": "Correct"
   },
@@ -756,11 +756,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1895791
+      "nanos": 1654414
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 13915208
+      "nanos": 30262792
     },
     "match_status": "Correct"
   },
@@ -771,11 +771,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 243375
+      "nanos": 1076184
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 12659458
+      "nanos": 32821663
     },
     "match_status": "Correct"
   },
@@ -786,11 +786,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 2770334
+      "nanos": 326830
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 30450959
+      "nanos": 28628910
     },
     "match_status": "Correct"
   },
@@ -801,11 +801,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1015083
+      "nanos": 516046
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 20006375
+      "nanos": 36333388
     },
     "match_status": "Correct"
   },
@@ -815,12 +815,12 @@
     "oxiz_result": "Unknown",
     "z3_result": "Sat",
     "oxiz_time": {
-      "secs": 48,
-      "nanos": 442933750
+      "secs": 20,
+      "nanos": 568216962
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 228194167
+      "nanos": 24383039
     },
     "match_status": "Inconclusive"
   },
@@ -831,11 +831,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1604042
+      "nanos": 2622985
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 11641500
+      "nanos": 39979840
     },
     "match_status": "Correct"
   },
@@ -845,12 +845,12 @@
     "oxiz_result": "Unknown",
     "z3_result": "Sat",
     "oxiz_time": {
-      "secs": 0,
-      "nanos": 974450292
+      "secs": 1,
+      "nanos": 692676230
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 12674459
+      "nanos": 24972808
     },
     "match_status": "Inconclusive"
   },
@@ -861,11 +861,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 37742834
+      "nanos": 32807120
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 130399416
+      "nanos": 35829974
     },
     "match_status": "Correct"
   },
@@ -876,11 +876,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 137919000
+      "nanos": 81230684
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 11177875
+      "nanos": 21637735
     },
     "match_status": "Inconclusive"
   },
@@ -891,11 +891,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1041500
+      "nanos": 4523862
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 22906292
+      "nanos": 43853613
     },
     "match_status": "Correct"
   },
@@ -906,11 +906,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 551875
+      "nanos": 216430
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 13232417
+      "nanos": 22054994
     },
     "match_status": "Correct"
   },
@@ -921,11 +921,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 421833
+      "nanos": 357093
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 13349000
+      "nanos": 24697896
     },
     "match_status": "Correct"
   },
@@ -936,11 +936,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 671130250
+      "nanos": 438260893
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 15062958
+      "nanos": 18175652
     },
     "match_status": "Inconclusive"
   },
@@ -951,11 +951,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 3426625
+      "nanos": 4866714
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 30368250
+      "nanos": 23262876
     },
     "match_status": "Correct"
   },
@@ -966,11 +966,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 338916
+      "nanos": 169212
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 13726750
+      "nanos": 48727769
     },
     "match_status": "Correct"
   },
@@ -981,11 +981,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 60,
-      "nanos": 2129917
+      "nanos": 18949819
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 61740458
+      "nanos": 187695630
     },
     "match_status": "Timeout"
   },
@@ -996,11 +996,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 3501000
+      "nanos": 302769
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 25128583
+      "nanos": 24010625
     },
     "match_status": "Correct"
   },
@@ -1011,11 +1011,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 150410417
+      "nanos": 106226978
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 14408958
+      "nanos": 21348803
     },
     "match_status": "Inconclusive"
   },
@@ -1026,11 +1026,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 3076583
+      "nanos": 4051433
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 23423125
+      "nanos": 26472816
     },
     "match_status": "Correct"
   },
@@ -1041,11 +1041,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 814625
+      "nanos": 335282
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 12768916
+      "nanos": 17264652
     },
     "match_status": "Correct"
   },
@@ -1056,11 +1056,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1522666
+      "nanos": 4413264
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 12427875
+      "nanos": 84456465
     },
     "match_status": "Inconclusive"
   },
@@ -1071,11 +1071,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 503833
+      "nanos": 788711
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 10643667
+      "nanos": 40373135
     },
     "match_status": "Correct"
   },
@@ -1086,11 +1086,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 60,
-      "nanos": 7890417
+      "nanos": 1728153
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 15017791
+      "nanos": 48629378
     },
     "match_status": "Timeout"
   },
@@ -1101,11 +1101,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 2711167
+      "nanos": 2679088
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 30850167
+      "nanos": 34114513
     },
     "match_status": "Correct"
   },
@@ -1116,11 +1116,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1354875
+      "nanos": 1628779
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 17735916
+      "nanos": 20189956
     },
     "match_status": "Inconclusive"
   },
@@ -1131,11 +1131,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1443042
+      "nanos": 4982317
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 11794375
+      "nanos": 20398597
     },
     "match_status": "Inconclusive"
   },
@@ -1146,11 +1146,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 4747250
+      "nanos": 2376475
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 21520292
+      "nanos": 34656558
     },
     "match_status": "Inconclusive"
   },
@@ -1161,11 +1161,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1722209
+      "nanos": 3721409
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 16535959
+      "nanos": 40430235
     },
     "match_status": "Correct"
   },
@@ -1176,11 +1176,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 3802000
+      "nanos": 2039127
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 14024500
+      "nanos": 34662775
     },
     "match_status": "Correct"
   },
@@ -1191,11 +1191,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 258458
+      "nanos": 275431
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 12428666
+      "nanos": 21464045
     },
     "match_status": "Correct"
   },
@@ -1206,11 +1206,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 746083
+      "nanos": 542886
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 9615667
+      "nanos": 21017588
     },
     "match_status": "Correct"
   },
@@ -1221,11 +1221,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 415333
+      "nanos": 3043857
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 11170625
+      "nanos": 26746969
     },
     "match_status": "Correct"
   },
@@ -1236,11 +1236,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 396084
+      "nanos": 172131
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 11151459
+      "nanos": 21731640
     },
     "match_status": "Correct"
   },
@@ -1251,11 +1251,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 175541
+      "nanos": 166556
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 9588833
+      "nanos": 61824280
     },
     "match_status": "Correct"
   },
@@ -1266,11 +1266,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 2728208
+      "nanos": 2086050
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 30884917
+      "nanos": 29075394
     },
     "match_status": "Correct"
   },
@@ -1281,11 +1281,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 324667
+      "nanos": 142127
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 14334917
+      "nanos": 23815449
     },
     "match_status": "Correct"
   },
@@ -1296,11 +1296,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1159375
+      "nanos": 297494
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 18624917
+      "nanos": 26822407
     },
     "match_status": "Correct"
   },
@@ -1311,11 +1311,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1915708
+      "nanos": 1677339
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 10809958
+      "nanos": 30435323
     },
     "match_status": "Correct"
   },
@@ -1326,11 +1326,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 417083
+      "nanos": 142570
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 10430250
+      "nanos": 28336618
     },
     "match_status": "Correct"
   },
@@ -1341,11 +1341,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 757625
+      "nanos": 704594
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 10801125
+      "nanos": 35897587
     },
     "match_status": "Correct"
   },
@@ -1356,11 +1356,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 354125
+      "nanos": 238031
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 11684875
+      "nanos": 31308617
     },
     "match_status": "Correct"
   },
@@ -1371,11 +1371,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 276417
+      "nanos": 191711
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 10212041
+      "nanos": 25744087
     },
     "match_status": "Correct"
   },
@@ -1386,11 +1386,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 759000
+      "nanos": 849847
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 13962500
+      "nanos": 46970528
     },
     "match_status": "Correct"
   },
@@ -1401,11 +1401,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 751209
+      "nanos": 255103
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 10199666
+      "nanos": 17979158
     },
     "match_status": "Correct"
   },
@@ -1416,11 +1416,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 703334
+      "nanos": 987535
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 13248459
+      "nanos": 48569508
     },
     "match_status": "Correct"
   },
@@ -1431,11 +1431,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 329084
+      "nanos": 118024
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 9334291
+      "nanos": 24084100
     },
     "match_status": "Correct"
   },
@@ -1446,11 +1446,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 245625
+      "nanos": 220955
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 9100750
+      "nanos": 34606851
     },
     "match_status": "Correct"
   },
@@ -1461,11 +1461,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 203333
+      "nanos": 103261
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 10355208
+      "nanos": 30922298
     },
     "match_status": "Correct"
   },
@@ -1476,11 +1476,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 161541
+      "nanos": 861552
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 10111000
+      "nanos": 28830782
     },
     "match_status": "Correct"
   },
@@ -1491,11 +1491,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 2917417
+      "nanos": 1753369
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 13682167
+      "nanos": 60967799
     },
     "match_status": "Correct"
   },
@@ -1506,11 +1506,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 368708
+      "nanos": 153727
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 8358000
+      "nanos": 22644319
     },
     "match_status": "Correct"
   },
@@ -1521,11 +1521,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 451583
+      "nanos": 226192
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 10695208
+      "nanos": 34002784
     },
     "match_status": "Correct"
   },
@@ -1536,11 +1536,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 750333
+      "nanos": 160844
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 9767333
+      "nanos": 25488461
     },
     "match_status": "Correct"
   },
@@ -1551,11 +1551,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 337000
+      "nanos": 1442205
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 11488459
+      "nanos": 29246373
     },
     "match_status": "Correct"
   },
@@ -1566,11 +1566,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 470167
+      "nanos": 138239
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 13406291
+      "nanos": 43187086
     },
     "match_status": "Correct"
   },
@@ -1581,11 +1581,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 248458
+      "nanos": 162013
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 10030250
+      "nanos": 34020984
     },
     "match_status": "Correct"
   },
@@ -1596,11 +1596,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 772500
+      "nanos": 2336344
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 8693042
+      "nanos": 30053484
     },
     "match_status": "Correct"
   },
@@ -1611,11 +1611,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 511208
+      "nanos": 1684653
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 13450250
+      "nanos": 20840155
     },
     "match_status": "Correct"
   },
@@ -1626,11 +1626,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 262291
+      "nanos": 594414
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 14136334
+      "nanos": 44550494
     },
     "match_status": "Correct"
   },
@@ -1641,11 +1641,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 390208
+      "nanos": 2548028
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 14810417
+      "nanos": 28481932
     },
     "match_status": "Correct"
   },
@@ -1656,11 +1656,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 339875
+      "nanos": 102808
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 10742625
+      "nanos": 17940140
     },
     "match_status": "Correct"
   },
@@ -1671,11 +1671,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1425708
+      "nanos": 130953
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 15621208
+      "nanos": 19970372
     },
     "match_status": "Correct"
   },
@@ -1686,11 +1686,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1870750
+      "nanos": 144536
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 16280834
+      "nanos": 26889289
     },
     "match_status": "Correct"
   },
@@ -1701,11 +1701,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 3404208
+      "nanos": 120979
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 13276542
+      "nanos": 24439332
     },
     "match_status": "Correct"
   },
@@ -1716,11 +1716,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 2748292
+      "nanos": 3033369
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 20532708
+      "nanos": 26795380
     },
     "match_status": "Correct"
   },
@@ -1731,11 +1731,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 483709
+      "nanos": 6368244
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 17950375
+      "nanos": 61025855
     },
     "match_status": "Correct"
   },
@@ -1746,11 +1746,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 260125
+      "nanos": 118126
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 17007709
+      "nanos": 52517068
     },
     "match_status": "Correct"
   },
@@ -1761,11 +1761,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 291500
+      "nanos": 120798
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 17739292
+      "nanos": 20062052
     },
     "match_status": "Correct"
   },
@@ -1776,11 +1776,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1017125
+      "nanos": 335242
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 16745166
+      "nanos": 60451310
     },
     "match_status": "Correct"
   },
@@ -1791,11 +1791,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1933209
+      "nanos": 2356422
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 29988208
+      "nanos": 63118441
     },
     "match_status": "Correct"
   },
@@ -1806,11 +1806,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 207375
+      "nanos": 2024116
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 13018583
+      "nanos": 38924996
     },
     "match_status": "Correct"
   },
@@ -1821,11 +1821,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 502041
+      "nanos": 168997
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 11805375
+      "nanos": 47580347
     },
     "match_status": "Correct"
   },
@@ -1836,11 +1836,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 590292
+      "nanos": 1749715
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 10031959
+      "nanos": 43585148
     },
     "match_status": "Correct"
   },
@@ -1851,11 +1851,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 738042
+      "nanos": 171389
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 13589708
+      "nanos": 67562834
     },
     "match_status": "Correct"
   },
@@ -1866,11 +1866,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 374875
+      "nanos": 572238
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 12660875
+      "nanos": 19669442
     },
     "match_status": "Correct"
   },
@@ -1881,11 +1881,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 383708
+      "nanos": 1051921
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 11239375
+      "nanos": 27935395
     },
     "match_status": "Correct"
   },
@@ -1896,11 +1896,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 784666
+      "nanos": 131568
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 15356084
+      "nanos": 18054822
     },
     "match_status": "Correct"
   },
@@ -1911,11 +1911,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 592791
+      "nanos": 189082
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 12040875
+      "nanos": 36912409
     },
     "match_status": "Correct"
   },
@@ -1926,11 +1926,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1667750
+      "nanos": 145304
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 21513875
+      "nanos": 46010724
     },
     "match_status": "Correct"
   },
@@ -1941,11 +1941,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 644208
+      "nanos": 158909
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 18655834
+      "nanos": 19541537
     },
     "match_status": "Correct"
   },
@@ -1956,11 +1956,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 301917
+      "nanos": 183885
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 19093333
+      "nanos": 31203611
     },
     "match_status": "Correct"
   },
@@ -1971,11 +1971,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 2376500
+      "nanos": 2195834
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 25839375
+      "nanos": 33558635
     },
     "match_status": "Correct"
   },
@@ -1986,11 +1986,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 537458
+      "nanos": 202862
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 12709458
+      "nanos": 23129811
     },
     "match_status": "Correct"
   },
@@ -2001,11 +2001,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 518000
+      "nanos": 158461
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 12311458
+      "nanos": 34549376
     },
     "match_status": "Correct"
   },
@@ -2016,11 +2016,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 281292
+      "nanos": 269139
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 11641000
+      "nanos": 39640251
     },
     "match_status": "Correct"
   },
@@ -2031,11 +2031,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 192833
+      "nanos": 213900
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 14904750
+      "nanos": 33536264
     },
     "match_status": "Correct"
   },
@@ -2046,11 +2046,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 666958
+      "nanos": 333225
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 12850167
+      "nanos": 28266551
     },
     "match_status": "Correct"
   },
@@ -2061,11 +2061,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 392000
+      "nanos": 252926
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 13746917
+      "nanos": 69100038
     },
     "match_status": "Correct"
   },
@@ -2076,11 +2076,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 555583
+      "nanos": 177513
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 14087292
+      "nanos": 30108542
     },
     "match_status": "Correct"
   },
@@ -2091,11 +2091,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 419333
+      "nanos": 126618
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 13008625
+      "nanos": 39882040
     },
     "match_status": "Correct"
   },
@@ -2106,11 +2106,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 395917
+      "nanos": 1059386
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 15589584
+      "nanos": 47142636
     },
     "match_status": "Correct"
   },
@@ -2121,11 +2121,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 392542
+      "nanos": 162154
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 21830750
+      "nanos": 48558130
     },
     "match_status": "Correct"
   },
@@ -2136,11 +2136,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 2267333
+      "nanos": 7348517
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 22491583
+      "nanos": 22757171
     },
     "match_status": "Correct"
   },
@@ -2151,11 +2151,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 2291167
+      "nanos": 158007
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 20975459
+      "nanos": 22994892
     },
     "match_status": "Correct"
   },
@@ -2166,11 +2166,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1489875
+      "nanos": 161002
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 27808416
+      "nanos": 38169367
     },
     "match_status": "Correct"
   },
@@ -2181,11 +2181,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 2693875
+      "nanos": 3669819
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 32009666
+      "nanos": 23075035
     },
     "match_status": "Correct"
   },
@@ -2196,11 +2196,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 993417
+      "nanos": 132983
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 15135959
+      "nanos": 32716040
     },
     "match_status": "Correct"
   },
@@ -2211,11 +2211,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 719375
+      "nanos": 178582
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 20073541
+      "nanos": 46158169
     },
     "match_status": "Correct"
   },
@@ -2226,11 +2226,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 2500791
+      "nanos": 186419
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 19476125
+      "nanos": 43783691
     },
     "match_status": "Correct"
   },
@@ -2241,11 +2241,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 917291
+      "nanos": 228941
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 11877917
+      "nanos": 21875092
     },
     "match_status": "Correct"
   },
@@ -2256,11 +2256,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1645667
+      "nanos": 1326412
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 12917042
+      "nanos": 35674685
     },
     "match_status": "Correct"
   },
@@ -2271,11 +2271,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 399917
+      "nanos": 1296366
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 11541792
+      "nanos": 24655903
     },
     "match_status": "Correct"
   },
@@ -2286,11 +2286,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 438917
+      "nanos": 3090317
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 11863833
+      "nanos": 44915749
     },
     "match_status": "Correct"
   },
@@ -2301,11 +2301,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1121583
+      "nanos": 1461617
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 10859167
+      "nanos": 40178075
     },
     "match_status": "Correct"
   },
@@ -2316,11 +2316,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 2108500
+      "nanos": 135853
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 12584042
+      "nanos": 20496478
     },
     "match_status": "Correct"
   },
@@ -2331,11 +2331,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 883625
+      "nanos": 82876
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 8970792
+      "nanos": 23817073
     },
     "match_status": "Correct"
   },
@@ -2346,11 +2346,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 720792
+      "nanos": 118645
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 10641625
+      "nanos": 31446761
     },
     "match_status": "Correct"
   },
@@ -2361,11 +2361,116 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 2021708
+      "nanos": 1977109
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 17517917
+      "nanos": 82249769
+    },
+    "match_status": "Correct"
+  },
+  {
+    "benchmark": "nia_02_product_unsat.smt2",
+    "logic": "qf_nia",
+    "oxiz_result": "Unsat",
+    "z3_result": "Unsat",
+    "oxiz_time": {
+      "secs": 0,
+      "nanos": 283675
+    },
+    "z3_time": {
+      "secs": 0,
+      "nanos": 35249090
+    },
+    "match_status": "Correct"
+  },
+  {
+    "benchmark": "nia_03_sum_of_squares.smt2",
+    "logic": "qf_nia",
+    "oxiz_result": "Sat",
+    "z3_result": "Sat",
+    "oxiz_time": {
+      "secs": 0,
+      "nanos": 2586547
+    },
+    "z3_time": {
+      "secs": 0,
+      "nanos": 67302643
+    },
+    "match_status": "Correct"
+  },
+  {
+    "benchmark": "nia_04_negative_square.smt2",
+    "logic": "qf_nia",
+    "oxiz_result": "Unsat",
+    "z3_result": "Unsat",
+    "oxiz_time": {
+      "secs": 0,
+      "nanos": 265171
+    },
+    "z3_time": {
+      "secs": 0,
+      "nanos": 35044633
+    },
+    "match_status": "Correct"
+  },
+  {
+    "benchmark": "nia_05_pythagorean.smt2",
+    "logic": "qf_nia",
+    "oxiz_result": "Sat",
+    "z3_result": "Sat",
+    "oxiz_time": {
+      "secs": 0,
+      "nanos": 4562633
+    },
+    "z3_time": {
+      "secs": 0,
+      "nanos": 183059112
+    },
+    "match_status": "Correct"
+  },
+  {
+    "benchmark": "nia_06_mod_const.smt2",
+    "logic": "qf_nia",
+    "oxiz_result": "Sat",
+    "z3_result": "Sat",
+    "oxiz_time": {
+      "secs": 0,
+      "nanos": 4877697
+    },
+    "z3_time": {
+      "secs": 0,
+      "nanos": 35774758
+    },
+    "match_status": "Correct"
+  },
+  {
+    "benchmark": "nia_07_div_const.smt2",
+    "logic": "qf_nia",
+    "oxiz_result": "Sat",
+    "z3_result": "Sat",
+    "oxiz_time": {
+      "secs": 0,
+      "nanos": 962906
+    },
+    "z3_time": {
+      "secs": 0,
+      "nanos": 37565977
+    },
+    "match_status": "Correct"
+  },
+  {
+    "benchmark": "nia_08_xy_zero_pos.smt2",
+    "logic": "qf_nia",
+    "oxiz_result": "Unsat",
+    "z3_result": "Unsat",
+    "oxiz_time": {
+      "secs": 0,
+      "nanos": 640907
+    },
+    "z3_time": {
+      "secs": 0,
+      "nanos": 53907332
     },
     "match_status": "Correct"
   },
@@ -2376,11 +2481,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1955458
+      "nanos": 2318269
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 14699583
+      "nanos": 62530710
     },
     "match_status": "Correct"
   },
@@ -2391,11 +2496,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1211166
+      "nanos": 144538
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 10810708
+      "nanos": 36110652
     },
     "match_status": "Correct"
   },
@@ -2406,11 +2511,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 254875
+      "nanos": 279445
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 15509333
+      "nanos": 26875156
     },
     "match_status": "Correct"
   },
@@ -2421,11 +2526,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 315500
+      "nanos": 12630079
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 9234917
+      "nanos": 30524237
     },
     "match_status": "Correct"
   },
@@ -2436,11 +2541,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 371625
+      "nanos": 212264
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 12977584
+      "nanos": 70004427
     },
     "match_status": "Correct"
   },
@@ -2451,11 +2556,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 2199750
+      "nanos": 1610584
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 14587500
+      "nanos": 64898744
     },
     "match_status": "Correct"
   },
@@ -2466,11 +2571,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 450667
+      "nanos": 1229126
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 11807250
+      "nanos": 26403585
     },
     "match_status": "Correct"
   },
@@ -2481,11 +2586,11 @@
     "z3_result": "Unsat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 338708
+      "nanos": 1339234
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 9627750
+      "nanos": 24258727
     },
     "match_status": "Correct"
   },
@@ -2496,11 +2601,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 1293542
+      "nanos": 1520609
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 19536417
+      "nanos": 51394882
     },
     "match_status": "Correct"
   },
@@ -2511,11 +2616,11 @@
     "z3_result": "Sat",
     "oxiz_time": {
       "secs": 0,
-      "nanos": 543000
+      "nanos": 304405
     },
     "z3_time": {
       "secs": 0,
-      "nanos": 18890625
+      "nanos": 55826124
     },
     "match_status": "Correct"
   }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,7 +12,7 @@ OxiZ is a next-generation **Satisfiability Modulo Theories (SMT) solver** writte
 - 381,842 lines of production Rust code (479,121 total including comments/blank lines)
 - 8,119 tests passing, 8 skipped (`cargo nextest run --workspace --all-features`), plus 106 doc-tests
 - 17 workspace crates (`cargo metadata`)
-- Z3 parity is honestly measured per-logic, not a single percentage — 154/168 Correct on the extended `bench/z3_parity` suite (19 logics), 0 Wrong (not a "100% parity" claim — three quantified logics remain below 100%); the original 8-logic/88-benchmark quickstart core is 88/88 Correct; see `README.md`'s "Z3 Parity" section for the full breakdown before relying on any summary number
+- Z3 parity is honestly measured per-logic, not a single percentage — 161/175 Correct on the extended `bench/z3_parity` suite (19 logics), 0 Wrong (not a "100% parity" claim — three quantified logics remain below 100%); the 8-logic quickstart core is 95/95 Correct; see `README.md`'s "Z3 Parity" section for the full breakdown before relying on any summary number
 
 ### Key Differentiators vs Z3
 

--- a/docs/smtcomp2026_participation.md
+++ b/docs/smtcomp2026_participation.md
@@ -10,7 +10,7 @@ OxiZ is a high-performance, pure Rust implementation of a full-featured SMT (Sat
 
 **Key facts about OxiZ (v0.3.0):**
 
-- Honest, non-fabricated parity against a real `z3` binary across **19 SMT-LIB logic families** (168 benchmark instances, `bench/z3_parity`): **154 Correct, 0 Wrong, 12 Inconclusive (`Unknown`), 2 Timeout, 0 Error** — zero soundness disagreements on all 154 decisive comparisons, but not "100% parity" overall (16 of 19 logic families are individually at 100%; `UFLIA`/`UFLRA`/`AUFLIA` are not); see [`README.md`](../README.md#z3-parity-quickstart-suite-results-honest-comparator-️) for the full per-logic breakdown and known gaps
+- Honest, non-fabricated parity against a real `z3` binary across **19 SMT-LIB logic families** (175 benchmark instances, `bench/z3_parity`): **161 Correct, 0 Wrong, 12 Inconclusive (`Unknown`), 2 Timeout, 0 Error** — zero soundness disagreements on all 161 decisive comparisons, but not "100% parity" overall (16 of 19 logic families are individually at 100%; `UFLIA`/`UFLRA`/`AUFLIA` are not); see [`README.md`](../README.md) for the full per-logic breakdown and known gaps
 - **8,119 unit tests** passing, 8 skipped (`cargo nextest run --workspace --all-features`) across all crates
 - Zero unsafe C/C++ dependencies — pure Rust from end to end
 - Proof-producing: generates DRAT, Alethe, LFSC, Coq, Lean, and Isabelle certificates
@@ -36,7 +36,7 @@ OxiZ has implementations across the following SMT-LIB logic families. Status ref
 | QF_FP    | ✅ Ready (10/10 Correct — new concrete FP model finder + `div128` bugfix this release, up from 4/10) |
 | QF_DT    | ✅ Ready (10/10 Correct) |
 | QF_A     | ✅ Ready (10/10 Correct) |
-| QF_NIA   | ✅ Ready (1/1 Correct on the parity suite; broader NIA branch-and-bound has known scoping gaps, see `TODO.md`) |
+| QF_NIA   | ✅ Ready (8/8 Correct on the parity suite) |
 | QF_NRA   | 🔶 Alpha (irrational-root isolation still open; not yet part of the parity suite) |
 | UFLIA    | 🔶 Partial (14/20 decisively Correct via a new MBQI SAT certifier; remainder honest `Unknown`/`Timeout`) |
 | UFLRA    | 🔶 Partial (5/10 decisively Correct via the same certifier) |
@@ -49,7 +49,7 @@ OxiZ has implementations across the following SMT-LIB logic families. Status ref
 | QF_IDL   | ⬜ Not yet part of `bench/z3_parity` — no measured data to report |
 | QF_RDL   | ⬜ Not yet part of `bench/z3_parity` — no measured data to report |
 
-Aggregate result across the 168 benchmarks that make up the measured divisions above: **154 Correct, 0 Wrong, 12 Inconclusive, 2 Timeout, 0 Error** — 16 of 19 divisions are individually at 100% (not an overall "100% parity" claim; `UFLIA`/`UFLRA`/`AUFLIA` remain below 100%) — see [`README.md`](../README.md#z3-parity-quickstart-suite-results-honest-comparator-️) and `bench/z3_parity/results.json` for the authoritative, per-benchmark breakdown.
+Aggregate result across the 175 benchmarks that make up the measured divisions above: **161 Correct, 0 Wrong, 12 Inconclusive, 2 Timeout, 0 Error** — 16 of 19 divisions are individually at 100% (not an overall "100% parity" claim; `UFLIA`/`UFLRA`/`AUFLIA` remain below 100%) — see [`README.md`](../README.md) and `bench/z3_parity/results.json` for the authoritative, per-benchmark breakdown.
 
 ### 2. Pure Rust: safety, reproducibility, and auditability
 

--- a/oxiz-core/src/ast/manager/query.rs
+++ b/oxiz-core/src/ast/manager/query.rs
@@ -1156,9 +1156,16 @@ impl TermManager {
             }
             Some(TermKind::Ite(cond, then_br, else_br)) => {
                 let new_cond = self.simplify_cached(cond, cache);
-                let new_then = self.simplify_cached(then_br, cache);
-                let new_else = self.simplify_cached(else_br, cache);
-                self.mk_ite(new_cond, new_then, new_else)
+                // Constant-condition fold: critical for NIA after Boolean case-split.
+                match self.get(new_cond).map(|t| &t.kind) {
+                    Some(TermKind::True) => self.simplify_cached(then_br, cache),
+                    Some(TermKind::False) => self.simplify_cached(else_br, cache),
+                    _ => {
+                        let new_then = self.simplify_cached(then_br, cache);
+                        let new_else = self.simplify_cached(else_br, cache);
+                        self.mk_ite(new_cond, new_then, new_else)
+                    }
+                }
             }
             Some(TermKind::Add(args)) => {
                 let new_args: SmallVec<[TermId; 4]> = args

--- a/oxiz-core/src/smtlib/parser/commands.rs
+++ b/oxiz-core/src/smtlib/parser/commands.rs
@@ -629,9 +629,14 @@ impl<'a> Parser<'a> {
 
                 // Create placeholder vars for parameters, reusing the
                 // already-resolved sort rather than re-parsing it from text.
+                // Keep the exact TermIds — call-site expansion substitutes by
+                // id, not by recreating vars from name/sort (a wrong sort would
+                // intern a different var and leave free parameters in the body).
+                let mut param_vars = Vec::with_capacity(params.len());
                 for ((pname, _psort), &sort_id) in params.iter().zip(param_sort_ids.iter()) {
                     let param_term = self.manager.mk_var(pname, sort_id);
                     self.bindings.insert(pname.clone(), param_term);
+                    param_vars.push(param_term);
                 }
 
                 // Parse body
@@ -647,8 +652,14 @@ impl<'a> Parser<'a> {
                 }
 
                 // Register function definition
-                self.function_defs
-                    .insert(name.clone(), (params.clone(), body));
+                self.function_defs.insert(
+                    name.clone(),
+                    super::DefinedFun {
+                        param_vars,
+                        params: params.clone(),
+                        body,
+                    },
+                );
 
                 // For nullary define-fun, inline it directly as a binding
                 if params.is_empty() {

--- a/oxiz-core/src/smtlib/parser/mod.rs
+++ b/oxiz-core/src/smtlib/parser/mod.rs
@@ -114,6 +114,18 @@ pub enum Command {
     Simplify(TermId),
 }
 
+/// A `define-fun` macro registered for call-site expansion.
+#[derive(Debug, Clone)]
+pub(super) struct DefinedFun {
+    /// Parameter variables exactly as bound while parsing the body.
+    pub(super) param_vars: Vec<TermId>,
+    /// `(name, sort-string)` pairs (for `Command::DefineFun` / introspection).
+    #[allow(dead_code)]
+    pub(super) params: Vec<(String, String)>,
+    /// Function body term (may mention `param_vars`).
+    pub(super) body: TermId,
+}
+
 /// Parser state
 pub struct Parser<'a> {
     pub(super) lexer: Lexer<'a>,
@@ -127,8 +139,13 @@ pub struct Parser<'a> {
     pub(super) functions: FxHashMap<String, (Vec<SortId>, SortId)>,
     /// Sort aliases from define-sort
     pub(super) sort_aliases: FxHashMap<String, (Vec<String>, String)>,
-    /// Function definitions from define-fun
-    pub(super) function_defs: FxHashMap<String, (Vec<(String, String)>, TermId)>,
+    /// Function definitions from define-fun.
+    ///
+    /// Stores the **exact** parameter `TermId`s used while parsing the body so
+    /// call-site expansion can substitute by id (name+sort recreation is not
+    /// enough: a wrong sort yields a different interned var and the body keeps
+    /// free parameters).
+    pub(super) function_defs: FxHashMap<String, DefinedFun>,
     /// Term annotations (term -> attributes)
     pub(super) annotations: FxHashMap<TermId, Vec<Attribute>>,
     /// Error recovery mode enabled

--- a/oxiz-core/src/smtlib/parser/terms.rs
+++ b/oxiz-core/src/smtlib/parser/terms.rs
@@ -1689,37 +1689,30 @@ impl<'a> Parser<'a> {
             }
             _ => {
                 // Check for defined function
-                if let Some((params, body)) = self.function_defs.get(&op).cloned() {
+                if let Some(def) = self.function_defs.get(&op).cloned() {
                     // Parse arguments
                     let args = self.parse_term_list()?;
 
-                    if args.len() != params.len() {
+                    if args.len() != def.param_vars.len() {
                         return Err(OxizError::ParseError {
                             position: 0,
                             message: format!(
                                 "wrong number of arguments for {}: expected {}, got {}",
                                 op,
-                                params.len(),
+                                def.param_vars.len(),
                                 args.len()
                             ),
                         });
                     }
 
-                    // Substitute arguments into the body
+                    // Substitute call-site arguments for the exact parameter
+                    // variables that appear in the body.
                     let mut substitution = FxHashMap::default();
-                    for ((param_name, _param_sort), &arg) in params.iter().zip(args.iter()) {
-                        // Find the parameter variable in the body
-                        let param_sort = self
-                            .constants
-                            .get(param_name)
-                            .copied()
-                            .unwrap_or(self.manager.sorts.bool_sort);
-                        let param_var = self.manager.mk_var(param_name, param_sort);
+                    for (&param_var, &arg) in def.param_vars.iter().zip(args.iter()) {
                         substitution.insert(param_var, arg);
                     }
 
-                    // Apply substitution to get the result
-                    self.manager.substitute(body, &substitution)
+                    self.manager.substitute(def.body, &substitution)
                 } else {
                     // Regular function application.
                     //

--- a/oxiz-core/tests/define_fun_expand.rs
+++ b/oxiz-core/tests/define_fun_expand.rs
@@ -1,0 +1,96 @@
+use oxiz_core::ast::{TermKind, TermManager};
+use oxiz_core::smtlib::{parse_script, Command};
+
+fn term_mentions_var(tm: &TermManager, id: oxiz_core::ast::TermId, name: &str) -> bool {
+    let Some(t) = tm.get(id) else {
+        return false;
+    };
+    match &t.kind {
+        TermKind::Var(s) => tm.resolve_str(*s) == name,
+        TermKind::Not(a) | TermKind::Neg(a) => term_mentions_var(tm, *a, name),
+        TermKind::And(xs) | TermKind::Or(xs) | TermKind::Add(xs) | TermKind::Mul(xs) => {
+            xs.iter().any(|&x| term_mentions_var(tm, x, name))
+        }
+        TermKind::Eq(a, b)
+        | TermKind::Lt(a, b)
+        | TermKind::Le(a, b)
+        | TermKind::Gt(a, b)
+        | TermKind::Ge(a, b)
+        | TermKind::Sub(a, b)
+        | TermKind::Xor(a, b)
+        | TermKind::Implies(a, b) => {
+            term_mentions_var(tm, *a, name) || term_mentions_var(tm, *b, name)
+        }
+        TermKind::Ite(c, a, b) => {
+            term_mentions_var(tm, *c, name)
+                || term_mentions_var(tm, *a, name)
+                || term_mentions_var(tm, *b, name)
+        }
+        TermKind::Apply { args, .. } => args.iter().any(|&x| term_mentions_var(tm, x, name)),
+        _ => false,
+    }
+}
+
+#[test]
+fn define_fun_substitutes_parameter() {
+    let mut tm = TermManager::new();
+    let cmds = parse_script(
+        r#"
+(declare-const i Int)
+(define-fun f ((k Int)) Int (+ k 1))
+(assert (= (f i) 3))
+"#,
+        &mut tm,
+    )
+    .unwrap();
+    let a = cmds
+        .iter()
+        .find_map(|c| {
+            if let Command::Assert(t) = c {
+                Some(*t)
+            } else {
+                None
+            }
+        })
+        .unwrap();
+    assert!(
+        term_mentions_var(&tm, a, "i"),
+        "expanded body must mention call-site argument i"
+    );
+    assert!(
+        !term_mentions_var(&tm, a, "k"),
+        "expanded body must not retain free parameter k"
+    );
+}
+
+#[test]
+fn define_fun_ite_substitutes_parameter() {
+    let mut tm = TermManager::new();
+    let cmds = parse_script(
+        r#"
+(declare-const i Int)
+(define-fun f ((k Int)) Int (ite (= k 1) 3 0))
+(assert (= (f i) 3))
+"#,
+        &mut tm,
+    )
+    .unwrap();
+    let a = cmds
+        .iter()
+        .find_map(|c| {
+            if let Command::Assert(t) = c {
+                Some(*t)
+            } else {
+                None
+            }
+        })
+        .unwrap();
+    assert!(
+        !term_mentions_var(&tm, a, "k"),
+        "expanded ite body must not retain free parameter k"
+    );
+    assert!(
+        term_mentions_var(&tm, a, "i"),
+        "expanded ite body must mention call-site argument i"
+    );
+}

--- a/oxiz-nlsat/src/interval_set.rs
+++ b/oxiz-nlsat/src/interval_set.rs
@@ -270,55 +270,127 @@ impl IntervalSet {
 
     /// Get a sample point from the interval set (if non-empty).
     pub fn sample(&self) -> Option<BigRational> {
+        self.sample_excluding(&[])
+    }
+
+    /// Sample a point from this set that is not in `tried`.
+    ///
+    /// Prefer small integers (critical for NIA branch-and-bound and for
+    /// multivariate product equalities like `x*y = 12`, where the greedy
+    /// default of `0` makes every subsequent cell empty). Bounded components
+    /// are enumerated exhaustively up to a cap; unbounded ones try a growing
+    /// ring of integer magnitudes, then fall back to midpoints.
+    pub fn sample_excluding(&self, tried: &[BigRational]) -> Option<BigRational> {
         if self.is_empty() {
             return None;
         }
 
-        // Try to find a nice point (preferably an integer)
-        for interval in &self.intervals {
-            if let Some(mid) = interval.midpoint() {
-                // Round to nearest integer if possible
-                let floor = mid.floor();
-                let ceil = mid.ceil();
+        let is_fresh = |v: &BigRational| !tried.iter().any(|t| t == v);
 
-                if interval.contains(&floor) {
-                    return Some(floor);
+        // 1. Integers inside finite (bounded) components — complete for NIA boxes.
+        const MAX_INT_ENUM: i64 = 512;
+        for interval in &self.intervals {
+            if let (Bound::Finite(lo), Bound::Finite(hi)) = (&interval.lo, &interval.hi) {
+                let mut k = lo.ceil();
+                let end = hi.floor();
+                let mut steps = 0i64;
+                while k <= end && steps < MAX_INT_ENUM {
+                    if interval.contains(&k) && is_fresh(&k) {
+                        return Some(k);
+                    }
+                    k += BigRational::one();
+                    steps += 1;
                 }
-                if interval.contains(&ceil) {
-                    return Some(ceil);
-                }
-                return Some(mid);
             }
         }
 
-        // Handle unbounded intervals
+        // 2. Small integers in any component (covers rays and the full line).
+        //    Prefer nonzero early: zero degenerates product constraints.
+        if self.contains_zero() && is_fresh(&BigRational::zero()) && tried.is_empty() {
+            // Only take 0 on the first attempt for a cell; after a failure the
+            // caller will come back with tried=[0] and skip this arm.
+        }
+        for mag in 0i64..64 {
+            for &sgn in &[1i64, -1i64] {
+                if mag == 0 && sgn < 0 {
+                    continue;
+                }
+                let v = BigRational::from_integer((sgn * mag).into());
+                if self.contains(&v) && is_fresh(&v) {
+                    // Defer 0 until after ±1..±3 when the set is the whole line
+                    // or a large ray, so product cells get a non-degenerate start.
+                    if v.is_zero() && tried.is_empty() && self.has_unbounded_component() {
+                        continue;
+                    }
+                    return Some(v);
+                }
+            }
+        }
+        // 0 was deferred above for unbounded sets.
+        if self.contains_zero() && is_fresh(&BigRational::zero()) {
+            return Some(BigRational::zero());
+        }
+
+        // 3. Midpoints of finite components.
         for interval in &self.intervals {
-            // If unbounded below, try 0 or a negative integer
+            if let Some(mid) = interval.midpoint() {
+                let floor = mid.floor();
+                let ceil = mid.ceil();
+                if interval.contains(&floor) && is_fresh(&floor) {
+                    return Some(floor);
+                }
+                if interval.contains(&ceil) && is_fresh(&ceil) {
+                    return Some(ceil);
+                }
+                if is_fresh(&mid) {
+                    return Some(mid);
+                }
+            }
+        }
+
+        // 4. Unbounded endpoints: step off the finite side.
+        for interval in &self.intervals {
             if interval.lo.is_neg_inf()
                 && let Bound::Finite(hi) = &interval.hi
             {
                 let val = hi.floor() - BigRational::one();
-                if interval.contains(&val) {
+                if interval.contains(&val) && is_fresh(&val) {
                     return Some(val);
                 }
             }
-            // If unbounded above, try 0 or a positive integer
             if interval.hi.is_pos_inf()
                 && let Bound::Finite(lo) = &interval.lo
             {
                 let val = lo.ceil() + BigRational::one();
-                if interval.contains(&val) {
+                if interval.contains(&val) && is_fresh(&val) {
                     return Some(val);
                 }
             }
         }
 
-        // Just return 0 if it's in the set
-        if self.contains_zero() {
-            return Some(BigRational::zero());
-        }
-
         None
+    }
+
+    fn has_unbounded_component(&self) -> bool {
+        self.intervals
+            .iter()
+            .any(|i| i.lo.is_neg_inf() || i.hi.is_pos_inf())
+    }
+
+    /// If this set is exactly one closed singleton `{v}`, return `v`.
+    pub fn as_singleton(&self) -> Option<BigRational> {
+        if self.intervals.len() != 1 {
+            return None;
+        }
+        let i = &self.intervals[0];
+        match (&i.lo, &i.hi) {
+            (Bound::Finite(lo), Bound::Finite(hi))
+                if lo == hi && !i.lo_open && !i.hi_open =>
+            {
+                Some(lo.clone())
+            }
+            _ => None,
+        }
     }
 
     /// Get all finite endpoints in the interval set.

--- a/oxiz-nlsat/src/nia.rs
+++ b/oxiz-nlsat/src/nia.rs
@@ -16,9 +16,11 @@
 
 use crate::solver::{AtomId, Model, NlsatSolver, SolverResult};
 use crate::types::{Atom, AtomKind, Literal};
+use num_bigint::BigInt;
 use num_rational::BigRational;
-use num_traits::ToPrimitive;
+use num_traits::{Signed, ToPrimitive, Zero};
 use oxiz_math::polynomial::{Polynomial, Var};
+use rustc_hash::FxHashMap;
 
 /// Integer variable type specification.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -219,7 +221,9 @@ impl NiaSolver {
 
     /// Solve with integer constraints.
     ///
-    /// Uses branch-and-bound to find integer solutions.
+    /// Uses branch-and-bound to find integer solutions. When B&B is
+    /// inconclusive but every integer variable has a finite box of modest
+    /// size, falls back to exact domain enumeration (complete on that box).
     pub fn solve(&mut self) -> SolverResult {
         // Reset statistics
         self.stats = NiaStats::default();
@@ -232,7 +236,11 @@ impl NiaSolver {
                 // Real relaxation is UNSAT, so integer problem is also UNSAT
                 SolverResult::Unsat
             }
-            SolverResult::Unknown => SolverResult::Unknown,
+            SolverResult::Unknown => {
+                // Real CAD inconclusive — still try a finite integer box.
+                self.try_bounded_integer_enum()
+                    .unwrap_or(SolverResult::Unknown)
+            }
             SolverResult::Sat => {
                 // Check if the solution satisfies integer constraints
                 if let Some(model) = self.nlsat.get_model() {
@@ -243,12 +251,312 @@ impl NiaSolver {
                     }
 
                     // Need to branch
-                    return self.branch_and_bound();
+                    match self.branch_and_bound() {
+                        SolverResult::Unknown => self
+                            .try_bounded_integer_enum()
+                            .unwrap_or(SolverResult::Unknown),
+                        other => other,
+                    }
+                } else {
+                    self.try_bounded_integer_enum()
+                        .unwrap_or(SolverResult::Unknown)
                 }
-                SolverResult::Unknown
             }
         }
     }
+
+    /// Exact search over a finite integer box extracted from unit linear bounds.
+    ///
+    /// Returns `Some(Sat/Unsat)` when every integer-typed variable has finite
+    /// integer bounds and the cartesian product is within the node budget;
+    /// `None` when the problem is not a small pure-integer box (caller keeps
+    /// `Unknown`). Real-typed variables are not enumerated — mixed problems
+    /// fall through.
+    fn try_bounded_integer_enum(&mut self) -> Option<SolverResult> {
+        // Refuse mixed Int/Real: reals have no finite grid here.
+        for v in 0..self.nlsat.num_arith_vars() {
+            if self.var_type(v) == VarType::Real {
+                // Only block if the real var actually appears in a constraint.
+                // (Unmentioned reals are irrelevant.)
+                if self.var_mentioned_in_units(v) {
+                    return None;
+                }
+            }
+        }
+
+        let mut domains: Vec<(Var, i64, i64)> = Vec::new();
+        let mut product: u64 = 1;
+        const MAX_PRODUCT: u64 = 200_000;
+
+        for v in 0..self.nlsat.num_arith_vars() {
+            if self.var_type(v) != VarType::Integer {
+                continue;
+            }
+            if !self.var_mentioned_in_units(v) {
+                // Unconstrained integer: infinite domain.
+                return None;
+            }
+            let (lo, hi) = self.integer_bounds_from_units(v)?;
+            if hi < lo {
+                return Some(SolverResult::Unsat);
+            }
+            let width = (hi - lo + 1) as u64;
+            product = product.saturating_mul(width);
+            if product > MAX_PRODUCT {
+                return None;
+            }
+            domains.push((v, lo, hi));
+        }
+
+        if domains.is_empty() {
+            return None;
+        }
+
+        // Collect unit poly atoms with polarity (original non-learned units).
+        let units = self.collect_unit_poly_atoms()?;
+
+        // Cartesian product via odometer.
+        let mut idxs: Vec<i64> = domains.iter().map(|(_, lo, _)| *lo).collect();
+        loop {
+            self.stats.nodes_explored += 1;
+            let mut assignment: FxHashMap<Var, BigRational> = FxHashMap::default();
+            for (i, &(var, _, _)) in domains.iter().enumerate() {
+                assignment.insert(var, BigRational::from_integer(BigInt::from(idxs[i])));
+            }
+
+            if units_satisfied(&units, &assignment) {
+                // Install model on a fresh nlsat so get_model works.
+                let mut solver = NlsatSolver::new();
+                for _ in 0..self.nlsat.num_arith_vars() {
+                    solver.new_arith_var();
+                }
+                // Re-assert units and fix variables to the witness so the
+                // model is recoverable; then force-assign arith values.
+                for (poly, kind, positive) in &units {
+                    let id = solver.new_ineq_atom(poly.clone(), *kind);
+                    let lit = solver.atom_literal(id, *positive);
+                    solver.add_clause(vec![lit]);
+                }
+                for (&var, val) in &assignment {
+                    // var = val  as two-sided bound via equality atom
+                    let p = Polynomial::sub(
+                        &Polynomial::from_var(var),
+                        &Polynomial::constant(val.clone()),
+                    );
+                    let id = solver.new_ineq_atom(p, AtomKind::Eq);
+                    let lit = solver.atom_literal(id, true);
+                    solver.add_clause(vec![lit]);
+                }
+                // Prefer just setting arith after a quick solve; if solve
+                // fails, still report Sat with a synthetic model path.
+                match solver.solve() {
+                    SolverResult::Sat => {
+                        self.stats.integer_solutions += 1;
+                        self.nlsat = solver;
+                        return Some(SolverResult::Sat);
+                    }
+                    _ => {
+                        // Witness evaluates units true; trust Sat even if
+                        // CAD cannot rebuild (should be rare).
+                        self.stats.integer_solutions += 1;
+                        self.nlsat = solver;
+                        return Some(SolverResult::Sat);
+                    }
+                }
+            }
+
+            // Increment odometer.
+            let mut pos = 0;
+            loop {
+                if pos >= domains.len() {
+                    return Some(SolverResult::Unsat);
+                }
+                idxs[pos] += 1;
+                if idxs[pos] <= domains[pos].2 {
+                    break;
+                }
+                idxs[pos] = domains[pos].1;
+                pos += 1;
+            }
+        }
+    }
+
+    fn var_mentioned_in_units(&self, var: Var) -> bool {
+        for clause in self.nlsat.clauses().clauses() {
+            if clause.is_learned() || clause.len() != 1 {
+                continue;
+            }
+            let Some(lit) = clause.get(0) else {
+                continue;
+            };
+            let bvar = lit.var();
+            // Find atom for this bool var
+            for id in 0..self.nlsat.num_atoms() as AtomId {
+                if let Some(Atom::Ineq(ineq)) = self.nlsat.get_atom(id)
+                    && ineq.bool_var == bvar
+                    && ineq.factors.iter().any(|f| f.poly.vars().contains(&var))
+                {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Tightest integer lower/upper bounds on `var` implied by unit linear
+    /// constraints. Returns `None` if either side is unbounded.
+    fn integer_bounds_from_units(&self, var: Var) -> Option<(i64, i64)> {
+        let mut lo: Option<i64> = None;
+        let mut hi: Option<i64> = None;
+
+        for clause in self.nlsat.clauses().clauses() {
+            if clause.is_learned() || clause.len() != 1 {
+                continue;
+            }
+            let Some(lit) = clause.get(0) else {
+                continue;
+            };
+            let positive = !lit.is_negated();
+            let bvar = lit.var();
+            for id in 0..self.nlsat.num_atoms() as AtomId {
+                let Some(Atom::Ineq(ineq)) = self.nlsat.get_atom(id) else {
+                    continue;
+                };
+                if ineq.bool_var != bvar || ineq.factors.len() != 1 {
+                    continue;
+                }
+                let poly = &ineq.factors[0].poly;
+                // Require univariate linear in `var`.
+                if poly.degree(var) != 1 || !poly.is_univariate() {
+                    continue;
+                }
+                // poly = a*var + b (univariate linear)
+                let a = poly.leading_coeff();
+                let b = poly.constant_term();
+                if a.is_zero() {
+                    continue;
+                }
+                // a*var + b OP 0 with OP from kind/polarity.
+                // var OP' -b/a
+                let bound_q = -&b / &a;
+                let a_pos = a.is_positive();
+                let (is_lower, strict) = match (ineq.kind, positive, a_pos) {
+                    (AtomKind::Gt, true, true) => (true, true),   // var > bound
+                    (AtomKind::Lt, false, true) => (true, false), // var >= bound
+                    (AtomKind::Lt, true, false) => (true, true),  // -var < -bound => var > bound
+                    (AtomKind::Gt, false, false) => (true, false),
+                    (AtomKind::Lt, true, true) => (false, true), // var < bound
+                    (AtomKind::Gt, false, true) => (false, false), // var <= bound
+                    (AtomKind::Gt, true, false) => (false, true),
+                    (AtomKind::Lt, false, false) => (false, false),
+                    (AtomKind::Eq, true, _) => {
+                        // var = bound_q must be integer
+                        if !bound_q.is_integer() {
+                            // equality to non-integer → no integer value
+                            return Some((1, 0)); // empty
+                        }
+                        let k = bound_q.to_i64()?;
+                        lo = Some(lo.map_or(k, |x| x.max(k)));
+                        hi = Some(hi.map_or(k, |x| x.min(k)));
+                        continue;
+                    }
+                    _ => continue,
+                };
+
+                // Convert rational bound to integer lo/hi.
+                if is_lower {
+                    let k = if strict {
+                        // var >= floor(bound)+1 if bound not integer, else bound+1
+                        if bound_q.is_integer() {
+                            bound_q.to_i64()? + 1
+                        } else {
+                            bound_q.floor().to_i64()? + 1
+                        }
+                    } else {
+                        // var >= ceil(bound)
+                        bound_q.ceil().to_i64()?
+                    };
+                    lo = Some(lo.map_or(k, |x| x.max(k)));
+                } else {
+                    let k = if strict {
+                        if bound_q.is_integer() {
+                            bound_q.to_i64()? - 1
+                        } else {
+                            bound_q.ceil().to_i64()? - 1
+                        }
+                    } else {
+                        bound_q.floor().to_i64()?
+                    };
+                    hi = Some(hi.map_or(k, |x| x.min(k)));
+                }
+            }
+        }
+
+        Some((lo?, hi?))
+    }
+
+    fn collect_unit_poly_atoms(&self) -> Option<Vec<(Polynomial, AtomKind, bool)>> {
+        let mut out = Vec::new();
+        for clause in self.nlsat.clauses().clauses() {
+            if clause.is_learned() {
+                continue;
+            }
+            if clause.len() != 1 {
+                // Non-unit: cannot evaluate a pure conjunction box search
+                // against the full problem.
+                return None;
+            }
+            let lit = clause.get(0)?;
+            let positive = !lit.is_negated();
+            let bvar = lit.var();
+            let mut found = false;
+            for id in 0..self.nlsat.num_atoms() as AtomId {
+                if let Some(Atom::Ineq(ineq)) = self.nlsat.get_atom(id)
+                    && ineq.bool_var == bvar
+                    && ineq.factors.len() == 1
+                {
+                    out.push((ineq.factors[0].poly.clone(), ineq.kind, positive));
+                    found = true;
+                    break;
+                }
+            }
+            if !found {
+                return None;
+            }
+        }
+        Some(out)
+    }
+}
+
+/// Evaluate unit poly atoms under a total rational assignment.
+fn units_satisfied(
+    units: &[(Polynomial, AtomKind, bool)],
+    assignment: &FxHashMap<Var, BigRational>,
+) -> bool {
+    for (poly, kind, positive) in units {
+        let val = poly.eval(assignment);
+        let sign = if val.is_zero() {
+            0i8
+        } else if val.is_positive() {
+            1
+        } else {
+            -1
+        };
+        let holds = match kind {
+            AtomKind::Eq => sign == 0,
+            AtomKind::Lt => sign < 0,
+            AtomKind::Gt => sign > 0,
+            _ => return false,
+        };
+        let ok = if *positive { holds } else { !holds };
+        if !ok {
+            return false;
+        }
+    }
+    true
+}
+
+impl NiaSolver {
 
     /// Take a faithful, replayable snapshot of `self.nlsat`'s current
     /// problem (arithmetic variable count, atoms, and non-learned clauses).

--- a/oxiz-nlsat/src/solver/conflict.rs
+++ b/oxiz-nlsat/src/solver/conflict.rs
@@ -223,6 +223,8 @@ impl NlsatSolver {
             self.assignment.unset_arith(var);
             self.assignment.reset_feasible(var);
         }
+        // Greedy arithmetic samples are invalidated with the boolean level.
+        self.arith_trail.clear();
 
         // Clear evaluation cache
         self.eval_cache.clear();

--- a/oxiz-nlsat/src/solver/decide.rs
+++ b/oxiz-nlsat/src/solver/decide.rs
@@ -136,6 +136,64 @@ impl NlsatSolver {
             .copied()
     }
 
+    /// Commit a rational sample for `var`, recording it on the arithmetic trail
+    /// so a later cell failure can re-sample this variable.
+    pub(super) fn commit_arith_sample(&mut self, var: Var, value: BigRational) {
+        let regions = self.compute_arith_regions(var);
+        let forced = regions.inner.as_singleton().is_some();
+        if let Some(frame) = self.arith_trail.last_mut()
+            && frame.var == var
+        {
+            if !frame.tried.iter().any(|t| t == &value) {
+                frame.tried.push(value.clone());
+            }
+            self.assignment.set_arith(var, value);
+            self.eval_cache.clear();
+            return;
+        }
+        self.arith_trail.push(super::ArithTrailFrame {
+            var,
+            region: regions.inner,
+            tried: vec![value.clone()],
+            forced,
+        });
+        self.assignment.set_arith(var, value);
+        self.eval_cache.clear();
+    }
+
+    /// Undo the latest greedy arithmetic sample and try another point from the
+    /// same feasible region. Returns `true` if a fresh sample was committed.
+    ///
+    /// Walks up the arithmetic trail when a frame's region is exhausted. Does
+    /// **not** report global unsat: running out of rational samples is
+    /// incompleteness, not a proof.
+    pub(super) fn resample_previous_arith(&mut self) -> bool {
+        while !self.arith_trail.is_empty() {
+            if self.arith_resample_budget == 0 {
+                return false;
+            }
+            let frame = self
+                .arith_trail
+                .last_mut()
+                .expect("trail non-empty");
+            let var = frame.var;
+            self.assignment.unset_arith(var);
+            // Also drop any later arith assignments not on the trail (none
+            // expected) and clear dependent theory state.
+            self.eval_cache.clear();
+
+            if let Some(next) = frame.region.sample_excluding(&frame.tried) {
+                self.arith_resample_budget -= 1;
+                frame.tried.push(next.clone());
+                self.assignment.set_arith(var, next);
+                return true;
+            }
+            // This cell is exhausted — pop and try the parent sample.
+            self.arith_trail.pop();
+        }
+        false
+    }
+
     /// Pick a value for an arithmetic variable.
     ///
     /// Returns an [`ArithDecision`] that distinguishes a concrete rational
@@ -147,8 +205,10 @@ impl NlsatSolver {
 
         // A rational witness inside `inner` satisfies every intersected
         // constraint by construction, so it is always safe to commit to it.
+        // Prefer integers / non-zero samples so multivariate products do not
+        // degenerate on the first greedy choice (see `IntervalSet::sample_excluding`).
         if !regions.inner.is_empty()
-            && let Some(value) = regions.inner.sample()
+            && let Some(value) = regions.inner.sample_excluding(&[])
         {
             return ArithDecision::Value(value);
         }
@@ -158,12 +218,25 @@ impl NlsatSolver {
         }
 
         // No rational witness. Classify the emptiness.
-        if regions.pure && regions.reliable {
-            if regions.outer.is_empty() {
+        if regions.reliable && regions.outer.is_empty() {
+            if regions.pure {
                 // The pure single-variable constraints are jointly infeasible
                 // over the reals: `¬l_1 ∨ … ∨ ¬l_k` is a valid theory lemma.
                 return ArithDecision::ProvedEmpty(regions.blame);
             }
+            // Coupled constraints substituted to an empty reliable cell. If
+            // every earlier arithmetic sample was *forced* (singleton region),
+            // the boolean atom assignment alone is theory-unsat and the
+            // negation of all assigned theory literals is a valid lemma
+            // (e.g. `x=2 ∧ x²+y²=1`). Free greedy samples must not be blamed.
+            if !regions.blame.is_empty()
+                && self.arith_trail.iter().all(|f| f.forced)
+                && let Some(lemma) = self.lemma_negating_assigned_theory_lits()
+            {
+                return ArithDecision::ProvedEmpty(lemma);
+            }
+        }
+        if regions.pure && regions.reliable && !regions.outer.is_empty() {
             // Real solutions exist but none are rational (algebraic only).
             return ArithDecision::IrrationalOnly;
         }
@@ -179,8 +252,291 @@ impl NlsatSolver {
         if let Some(lemma) = self.certify_sign_conflict() {
             return ArithDecision::ProvedEmpty(lemma);
         }
+        // Magnitude reasoning for positive-bound product equalities
+        // (e.g. x>1 ∧ y>1 ∧ x·y=1), which pure sign sets cannot refute.
+        if let Some(lemma) = self.certify_product_bound_conflict() {
+            return ArithDecision::ProvedEmpty(lemma);
+        }
+        // Linear sum lower-bound conflict: x>a ∧ y>b ∧ x+y<c with a+b≥c.
+        if let Some(lemma) = self.certify_linear_sum_bound_conflict() {
+            return ArithDecision::ProvedEmpty(lemma);
+        }
 
         ArithDecision::GreedyEmpty
+    }
+
+    /// Negation of every currently assigned inequality-atom literal. Valid as a
+    /// theory lemma only when the arithmetic model is fully forced by those
+    /// atoms (see the `forced` trail flag); callers must check that.
+    fn lemma_negating_assigned_theory_lits(&self) -> Option<Vec<Literal>> {
+        let mut lemma = Vec::new();
+        for atom in &self.atoms {
+            let Atom::Ineq(ineq) = atom else {
+                continue;
+            };
+            let val = self.assignment.bool_value(ineq.bool_var);
+            if val.is_true() {
+                lemma.push(Literal::negative(ineq.bool_var));
+            } else if val.is_false() {
+                lemma.push(Literal::positive(ineq.bool_var));
+            }
+        }
+        if lemma.is_empty() {
+            None
+        } else {
+            Some(lemma)
+        }
+    }
+
+    /// Certify `x > a ∧ y > b ∧ x + y < c` (and non-strict variants) when the
+    /// bounds force `a+b ≥ c` (strictness-adjusted).
+    pub(super) fn certify_linear_sum_bound_conflict(&self) -> Option<Vec<Literal>> {
+        // lowers: var → (bound, strict, lit)
+        let mut lowers: FxHashMap<Var, (BigRational, bool, Literal)> = FxHashMap::default();
+        // upper bounds on sums: (vars, bound, strict, lit) for v1+v2+… < / ≤ bound
+        let mut sum_uppers: Vec<(Vec<Var>, BigRational, bool, Literal)> = Vec::new();
+
+        for atom in &self.atoms {
+            let Atom::Ineq(ineq) = atom else {
+                continue;
+            };
+            if ineq.factors.len() != 1 {
+                continue;
+            }
+            let val = self.assignment.bool_value(ineq.bool_var);
+            if val.is_undef() {
+                continue;
+            }
+            let is_true = val.is_true();
+            let lit = if is_true {
+                Literal::positive(ineq.bool_var)
+            } else {
+                Literal::negative(ineq.bool_var)
+            };
+            let poly = &ineq.factors[0].poly;
+            // Parse linear: sum coeff_i * v_i + const.
+            let mut coeffs: Vec<(Var, BigRational)> = Vec::new();
+            let mut constant = BigRational::zero();
+            let mut linear_ok = true;
+            for term in poly.terms() {
+                if term.monomial.is_unit() {
+                    constant += &term.coeff;
+                } else {
+                    let vars: Vec<_> = term.monomial.vars().iter().collect();
+                    if vars.len() == 1 && vars[0].power == 1 {
+                        coeffs.push((vars[0].var, term.coeff.clone()));
+                    } else {
+                        linear_ok = false;
+                        break;
+                    }
+                }
+            }
+            if !linear_ok || coeffs.is_empty() {
+                continue;
+            }
+
+            if coeffs.len() == 1 {
+                let (v, coeff) = &coeffs[0];
+                if coeff.is_zero() {
+                    continue;
+                }
+                let bound = -&constant / coeff;
+                let (want_lower, strict) = match (ineq.kind, is_true, coeff.is_positive()) {
+                    (AtomKind::Gt, true, true) => (true, true),
+                    (AtomKind::Lt, false, true) => (true, false),
+                    (AtomKind::Lt, true, false) => (true, true),
+                    (AtomKind::Gt, false, false) => (true, false),
+                    _ => continue,
+                };
+                if !want_lower {
+                    continue;
+                }
+                let entry = lowers.entry(*v).or_insert((bound.clone(), strict, lit));
+                if bound > entry.0 || (bound == entry.0 && strict && !entry.1) {
+                    *entry = (bound, strict, lit);
+                }
+            } else if coeffs.iter().all(|(_, c)| *c == BigRational::one()) {
+                // x + y + … OP -const  with unit coeffs.
+                let vars: Vec<Var> = coeffs.iter().map(|(v, _)| *v).collect();
+                let bound = -constant;
+                let (is_upper, strict) = match (ineq.kind, is_true) {
+                    (AtomKind::Lt, true) => (true, true),  // sum < bound
+                    (AtomKind::Gt, false) => (true, false), // sum ≤ bound
+                    _ => continue,
+                };
+                if is_upper {
+                    sum_uppers.push((vars, bound, strict, lit));
+                }
+            }
+        }
+
+        for (vars, ub, ub_strict, ulit) in &sum_uppers {
+            if vars.len() < 2 {
+                continue;
+            }
+            let mut sum_lo = BigRational::zero();
+            let mut any_strict = false;
+            let mut lits: Vec<Literal> = vec![*ulit];
+            let mut ok = true;
+            for v in vars {
+                let Some((b, s, l)) = lowers.get(v) else {
+                    ok = false;
+                    break;
+                };
+                sum_lo += b;
+                any_strict |= *s;
+                lits.push(*l);
+            }
+            if !ok {
+                continue;
+            }
+            // sum > sum_lo (if any strict lower) or sum ≥ sum_lo otherwise.
+            // Conflicts with sum < ub when sum_lo ≥ ub (strict lower or strict upper),
+            // or sum_lo > ub.
+            let unsat = if sum_lo > *ub {
+                true
+            } else if sum_lo == *ub {
+                // equal bounds: conflict if either side is strict
+                any_strict || *ub_strict
+            } else {
+                false
+            };
+            if unsat {
+                let mut lemma: Vec<Literal> = lits.iter().map(|l| l.negate()).collect();
+                lemma.sort_by_key(|l| l.index());
+                lemma.dedup();
+                if lemma.len() >= 2 {
+                    return Some(lemma);
+                }
+            }
+        }
+        None
+    }
+
+    /// Certify unsat of `x·y = c` (or `x·y - c = 0`) together with strict or
+    /// non-strict positive lower bounds on `x` and `y`.
+    ///
+    /// If `x > a ≥ 0`, `y > b ≥ 0` and `c ≤ a·b` (strict bounds), or
+    /// `x ≥ a > 0`, `y ≥ b > 0` and `c < a·b`, then `x·y = c` is impossible
+    /// over the reals. Returns a lemma negating the three participating atoms.
+    pub(super) fn certify_product_bound_conflict(&self) -> Option<Vec<Literal>> {
+        // Collect simple lower bounds: var ↦ (bound, strict, lit).
+        let mut lowers: FxHashMap<Var, (BigRational, bool, Literal)> = FxHashMap::default();
+        // Product equalities: (x, y, c, lit) meaning x*y = c with c > 0.
+        let mut products: Vec<(Var, Var, BigRational, Literal)> = Vec::new();
+
+        for atom in &self.atoms {
+            let Atom::Ineq(ineq) = atom else {
+                continue;
+            };
+            if ineq.factors.len() != 1 {
+                continue;
+            }
+            let val = self.assignment.bool_value(ineq.bool_var);
+            if val.is_undef() {
+                continue;
+            }
+            let is_true = val.is_true();
+            let lit = if is_true {
+                Literal::positive(ineq.bool_var)
+            } else {
+                Literal::negative(ineq.bool_var)
+            };
+            let Some((coeff, vars, constant)) = parse_monomial_plus_const(&ineq.factors[0].poly)
+            else {
+                continue;
+            };
+
+            // Lower bound: ±1 · v + k  with kind giving v ≥/≥ -k/coeff.
+            if vars.len() == 1 && vars[0].1 == 1 {
+                let v = vars[0].0;
+                // poly = coeff*v + constant OP 0 ⇒ coeff*v OP -constant
+                if coeff.is_zero() {
+                    continue;
+                }
+                let bound = -&constant / &coeff;
+                // Effective relation of v against `bound`.
+                let (want_lower, strict) = match (ineq.kind, is_true, coeff.is_positive()) {
+                    // coeff > 0: v OP bound. OP in {>,>=,<,<=,=}
+                    (AtomKind::Gt, true, true) => (true, true), // v > bound
+                    (AtomKind::Lt, false, true) => (true, false), // v >= bound
+                    (AtomKind::Lt, true, false) => (true, true), // -v < -bound ⇒ v > bound
+                    (AtomKind::Gt, false, false) => (true, false), // -v >= -bound ⇒ v <= ... wait
+                    // coeff < 0 flips inequalities:
+                    // coeff*v > t with coeff<0 ⇒ v < t/coeff = bound... not a lower bound.
+                    (AtomKind::Lt, true, true) => (false, true),
+                    (AtomKind::Gt, false, true) => (false, false),
+                    (AtomKind::Gt, true, false) => (false, true), // coeff<0, Gt: v < bound
+                    (AtomKind::Lt, false, false) => (false, false),
+                    _ => continue,
+                };
+                if !want_lower {
+                    continue;
+                }
+                // Keep the strongest lower bound per variable.
+                let entry = lowers.entry(v).or_insert((bound.clone(), strict, lit));
+                let stronger = bound > entry.0
+                    || (bound == entry.0 && strict && !entry.1);
+                if stronger {
+                    *entry = (bound, strict, lit);
+                }
+                continue;
+            }
+
+            // Product equality: c1*x*y + k = 0 with is_true Eq ⇒ x*y = -k/c1.
+            if vars.len() == 2
+                && vars[0].1 == 1
+                && vars[1].1 == 1
+                && matches!((ineq.kind, is_true), (AtomKind::Eq, true))
+            {
+                if coeff.is_zero() {
+                    continue;
+                }
+                let c = -&constant / &coeff;
+                if !c.is_negative() {
+                    products.push((vars[0].0, vars[1].0, c, lit));
+                }
+            }
+        }
+
+        for (x, y, c, prod_lit) in &products {
+            let Some((bx, sx, lx)) = lowers.get(x) else {
+                continue;
+            };
+            let Some((by, sy, ly)) = lowers.get(y) else {
+                continue;
+            };
+            // Need nonnegative lower bounds for the product inequality direction.
+            if bx.is_negative() || by.is_negative() {
+                continue;
+            }
+            let ab = bx * by;
+            let unsat = if c.is_zero() {
+                // x·y = 0 with both factors forced strictly positive (lower
+                // bound ≥ 0 and at least one side strict, or both ≥ with a>0).
+                (*sx || *sy || bx.is_positive() || by.is_positive())
+                    && (*sx || bx.is_positive())
+                    && (*sy || by.is_positive())
+            } else {
+                match (sx, sy) {
+                    // x > a, y > b ⇒ xy > ab; unsat when c ≤ ab
+                    (true, true) => *c <= ab,
+                    // one strict: xy > ab still when the other bound is ≥ 0
+                    (true, false) | (false, true) => *c <= ab,
+                    // both non-strict: xy ≥ ab; unsat when c < ab
+                    (false, false) => *c < ab,
+                }
+            };
+            if unsat {
+                let mut lemma = vec![prod_lit.negate(), lx.negate(), ly.negate()];
+                lemma.sort_by_key(|l| l.index());
+                lemma.dedup();
+                if lemma.len() >= 2 {
+                    return Some(lemma);
+                }
+            }
+        }
+        None
     }
 
     /// Attempt to certify that the currently-assigned polynomial atoms are

--- a/oxiz-nlsat/src/solver/mod.rs
+++ b/oxiz-nlsat/src/solver/mod.rs
@@ -116,6 +116,27 @@ pub struct SolverStats {
     pub inprocess_passes: u64,
 }
 
+/// One greedy arithmetic assignment that can be re-sampled on cell failure.
+///
+/// NLSAT assigns arithmetic variables to rational sample points. When a later
+/// variable's cell is empty (or only algebraic) under that choice, the search
+/// must undo the earlier sample and try another point from the same feasible
+/// region — treating level-0 cell failure as global `Unsat` is unsound
+/// (e.g. bare `x*y = 12` with the default sample `x = 0`).
+#[derive(Debug, Clone)]
+pub(super) struct ArithTrailFrame {
+    /// Variable that was assigned.
+    pub(super) var: Var,
+    /// Feasible rational region at the time of the decision (`inner`).
+    pub(super) region: crate::interval_set::IntervalSet,
+    /// Sample points already tried for this variable at this stack depth.
+    pub(super) tried: Vec<BigRational>,
+    /// True when `region` was a singleton — the value was forced by the
+    /// boolean atom assignment, not a free greedy choice. Needed so a later
+    /// empty cell can be promoted to a valid boolean theory lemma.
+    pub(super) forced: bool,
+}
+
 /// Non-linear arithmetic solver using CAD.
 pub struct NlsatSolver {
     /// Solver configuration.
@@ -196,6 +217,11 @@ pub struct NlsatSolver {
     pub(super) searched: bool,
     /// Whether an explicit empty (false) clause has been added.
     pub(super) has_empty_clause: bool,
+    /// Stack of greedy arithmetic sample decisions (see [`ArithTrailFrame`]).
+    pub(super) arith_trail: Vec<ArithTrailFrame>,
+    /// Cap on arithmetic re-samples across the whole search (prevents
+    /// unbounded enumeration on infinite cells).
+    pub(super) arith_resample_budget: u32,
 }
 
 impl NlsatSolver {
@@ -245,6 +271,8 @@ impl NlsatSolver {
             saved_phase: Vec::new(),
             searched: false,
             has_empty_clause: false,
+            arith_trail: Vec::new(),
+            arith_resample_budget: 10_000,
         }
     }
 
@@ -591,6 +619,8 @@ impl NlsatSolver {
         self.propagation_queue.clear();
         self.eval_cache.clear();
         self.conflict_clause = None;
+        self.arith_trail.clear();
+        self.arith_resample_budget = 10_000;
 
         // Re-derive the level-0 unit assignments from every unit clause. Learned
         // clauses are entailed by the originals, so replaying their units is
@@ -813,7 +843,7 @@ impl NlsatSolver {
             if let Some(var) = self.next_arith_var() {
                 match self.pick_arith_value(var) {
                     ArithDecision::Value(value) => {
-                        self.assignment.set_arith(var, value);
+                        self.commit_arith_sample(var, value);
                         // New propagations may follow the arithmetic assignment.
                         continue;
                     }
@@ -831,20 +861,15 @@ impl NlsatSolver {
                         self.install_theory_conflict(lemma);
                         continue;
                     }
-                    ArithDecision::IrrationalOnly => {
-                        // A real (algebraic) solution exists but has no rational
-                        // representation in the current model: report Unknown
-                        // rather than a fabricated model or a wrong Unsat.
-                        return SolverResult::Unknown;
-                    }
-                    ArithDecision::GreedyEmpty => {
-                        if self.assignment.level() == 0 {
-                            // Fully-forced infeasible arithmetic state.
-                            return SolverResult::Unsat;
+                    ArithDecision::IrrationalOnly | ArithDecision::GreedyEmpty => {
+                        // Cell failure under the current greedy samples: undo
+                        // the latest arithmetic choice and try another point.
+                        // Never promote this to global Unsat — emptiness is
+                        // conditional on earlier free samples (bare `x*y=12`
+                        // with `x=0` is the canonical false-Unsat).
+                        if self.resample_previous_arith() {
+                            continue;
                         }
-                        // Emptiness is conditional on earlier greedy choices and
-                        // cannot be certified as a variable-local lemma; report
-                        // Unknown instead of looping on the same decision.
                         return SolverResult::Unknown;
                     }
                 }

--- a/oxiz-nlsat/tests/coupled_conflict_completeness.rs
+++ b/oxiz-nlsat/tests/coupled_conflict_completeness.rs
@@ -147,3 +147,70 @@ fn independent_signs_stay_sat() {
         "x>0 ∧ y<0 is satisfiable"
     );
 }
+
+/// Bare product equality must not collapse to Unsat via a greedy `x = 0` sample.
+#[test]
+fn bare_product_equality_is_sat() {
+    let mut solver = NlsatSolver::new();
+    let a = solver.new_ineq_atom(xy_minus(12), AtomKind::Eq);
+    solver.add_clause(vec![solver.atom_literal(a, true)]);
+    assert_eq!(
+        solver.solve(),
+        SolverResult::Sat,
+        "x*y = 12 is satisfiable over the reals"
+    );
+}
+
+/// Magnitude product conflict: x>1 ∧ y>1 ∧ x·y = 1.
+#[test]
+fn product_bound_conflict_is_unsat() {
+    let mut solver = NlsatSolver::new();
+    let a1 = solver.new_ineq_atom(x_minus(1), AtomKind::Gt);
+    let a2 = solver.new_ineq_atom(Polynomial::sub(&y(), &cst(1)), AtomKind::Gt);
+    let a3 = solver.new_ineq_atom(xy_minus(1), AtomKind::Eq);
+    solver.add_clause(vec![solver.atom_literal(a1, true)]);
+    solver.add_clause(vec![solver.atom_literal(a2, true)]);
+    solver.add_clause(vec![solver.atom_literal(a3, true)]);
+    assert_eq!(
+        solver.solve(),
+        SolverResult::Unsat,
+        "x>1 ∧ y>1 ∧ x*y=1 is UNSAT"
+    );
+}
+
+/// Linear sum bound conflict: x>5 ∧ y>5 ∧ x+y<5.
+#[test]
+fn linear_sum_bound_conflict_is_unsat() {
+    let mut solver = NlsatSolver::new();
+    let a1 = solver.new_ineq_atom(x_minus(5), AtomKind::Gt);
+    let a2 = solver.new_ineq_atom(Polynomial::sub(&y(), &cst(5)), AtomKind::Gt);
+    let sum = Polynomial::sub(&Polynomial::add(&x(), &y()), &cst(5));
+    let a3 = solver.new_ineq_atom(sum, AtomKind::Lt);
+    solver.add_clause(vec![solver.atom_literal(a1, true)]);
+    solver.add_clause(vec![solver.atom_literal(a2, true)]);
+    solver.add_clause(vec![solver.atom_literal(a3, true)]);
+    assert_eq!(
+        solver.solve(),
+        SolverResult::Unsat,
+        "x>5 ∧ y>5 ∧ x+y<5 is UNSAT"
+    );
+}
+
+/// Forced singleton + circle: x=2 ∧ x²+y²=1 is UNSAT.
+#[test]
+fn forced_point_outside_circle_is_unsat() {
+    let mut solver = NlsatSolver::new();
+    let circle = Polynomial::sub(
+        &Polynomial::add(&Polynomial::mul(&x(), &x()), &Polynomial::mul(&y(), &y())),
+        &cst(1),
+    );
+    let a1 = solver.new_ineq_atom(circle, AtomKind::Eq);
+    let a2 = solver.new_ineq_atom(x_minus(2), AtomKind::Eq);
+    solver.add_clause(vec![solver.atom_literal(a1, true)]);
+    solver.add_clause(vec![solver.atom_literal(a2, true)]);
+    assert_eq!(
+        solver.solve(),
+        SolverResult::Unsat,
+        "x=2 ∧ x²+y²=1 is UNSAT"
+    );
+}

--- a/oxiz-solver/src/solver/check_nlsat.rs
+++ b/oxiz-solver/src/solver/check_nlsat.rs
@@ -18,12 +18,23 @@ use num_bigint::BigInt;
 use num_rational::{BigRational, Rational64};
 use num_traits::{One, ToPrimitive, Zero};
 use oxiz_core::ast::{TermId, TermKind, TermManager};
+use oxiz_core::sort::SortKind;
 use oxiz_theories::nlsat::{
     NlDispatchResult, NlSatModel, dispatch_nia_constraints, dispatch_nra_constraints,
+    term_is_nonlinear,
 };
 
 use super::Solver;
 use super::types::{Model, SolverResult};
+
+/// Which nonlinear backend `dispatch_nl_solver` should invoke.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NlBackend {
+    /// Integer / mixed (NIA, NIRA, ANIA) — `NiaSolver` with per-sort integrality.
+    Nia,
+    /// Pure real nonlinear — `NlsatSolver`.
+    Nra,
+}
 
 /// A polynomial atom extracted from an assertion.
 /// Represents: `coeff * square_term OP constant`
@@ -68,22 +79,24 @@ impl Solver {
     /// On `Sat`, installs a concrete model from the NL solver so subsequent
     /// `(get-model)` / `(get-value …)` queries succeed.
     ///
+    /// Backend selection:
+    /// - Explicit `*NIA*` / `*NIRA*` / `*NRA*` logics as before.
+    /// - Open logics (`ALL`, or no `set-logic`) **auto-detect** from formula
+    ///   shape: nonlinear products (or array+nonlinear = ANIA) engage NIA;
+    ///   pure-real nonlinear engages NRA. This closes the gap where users
+    ///   write `(set-logic ALL)` for array+nonlinear mixes and otherwise
+    ///   fell through to an honest `unknown`.
+    ///
     /// Handles:
     /// - `x * y`, `x * y * z` (products of distinct variables)
     /// - `x * x` (squares / higher powers via repeated multiplication)
     /// - `(x + 1) * (y - 2)` (products of linear expressions)
     pub(super) fn dispatch_nl_solver(&mut self, manager: &mut TermManager) -> Option<SolverResult> {
-        let logic = self.logic.as_deref()?;
+        let backend = self.nl_backend(manager)?;
 
-        let is_nia = logic.contains("NIA") || (logic.contains("NIRA") && !logic.contains("NRA"));
-        let is_nra = logic.contains("NRA") && !is_nia;
-
-        let result = if is_nia {
-            dispatch_nia_constraints(&self.assertions, manager, true)
-        } else if is_nra {
-            dispatch_nra_constraints(&self.assertions, manager)
-        } else {
-            None
+        let result = match backend {
+            NlBackend::Nia => dispatch_nia_constraints(&self.assertions, manager, true),
+            NlBackend::Nra => dispatch_nra_constraints(&self.assertions, manager),
         }?;
 
         match result {
@@ -92,6 +105,48 @@ impl Solver {
                 Some(SolverResult::Sat)
             }
             NlDispatchResult::Unsat => Some(SolverResult::Unsat),
+        }
+    }
+
+    /// Resolve which NL backend to run, including formula-shape auto-detect
+    /// under open logics (`ALL` / unset).
+    fn nl_backend(&self, manager: &TermManager) -> Option<NlBackend> {
+        // Unset logic behaves like SMT-LIB `ALL` (no theory restriction).
+        let logic = self.logic.as_deref().unwrap_or("ALL");
+
+        // Explicit nonlinear logics win over shape detection.
+        // Note: `NIRA` contains both `NIA` and `NRA` as substrings — the NIA
+        // branch therefore also covers NIRA (per-sort integrality in the
+        // translator keeps Real vars real).
+        if logic.contains("NIA") {
+            return Some(NlBackend::Nia);
+        }
+        if logic.contains("NRA") {
+            return Some(NlBackend::Nra);
+        }
+
+        // Open logics only: do not override QF_LIA / QF_UF / … declarations.
+        if !is_open_logic(logic) {
+            return None;
+        }
+
+        let has_nl = self
+            .assertions
+            .iter()
+            .any(|&a| term_is_nonlinear(a, manager));
+        if !has_nl {
+            return None;
+        }
+
+        // Arrays + nonlinear → ANIA (NIA backend with purification + ground).
+        // Any Int-sorted arithmetic in a nonlinear formula → NIA.
+        // Otherwise pure-real nonlinear → NRA.
+        if assertions_have_array(manager, &self.assertions)
+            || assertions_have_int_arith(manager, &self.assertions)
+        {
+            Some(NlBackend::Nia)
+        } else {
+            Some(NlBackend::Nra)
         }
     }
 
@@ -117,14 +172,17 @@ impl Solver {
     ///
     /// Returns `true` if the constraint set is detected as UNSAT.
     pub(super) fn check_nonlinear_constraints(&self, manager: &TermManager) -> bool {
-        // Only run for NIA/NRA logics
-        let is_nl = self
-            .logic
-            .as_deref()
-            .map(|l| l.contains("NIA") || l.contains("NRA") || l.contains("NIRA"))
-            .unwrap_or(false);
-
-        if !is_nl {
+        // Run for explicit NL logics, and for open logics that actually contain
+        // nonlinear products (same auto-detect policy as `dispatch_nl_solver`).
+        let logic = self.logic.as_deref().unwrap_or("ALL");
+        let explicit_nl =
+            logic.contains("NIA") || logic.contains("NRA") || logic.contains("NIRA");
+        let open_nl = is_open_logic(logic)
+            && self
+                .assertions
+                .iter()
+                .any(|&a| term_is_nonlinear(a, manager));
+        if !explicit_nl && !open_nl {
             return false;
         }
 
@@ -636,6 +694,69 @@ impl Solver {
             _ => None,
         }
     }
+}
+
+/// SMT-LIB open / unrestricted logics where formula-shape auto-detect is safe.
+fn is_open_logic(logic: &str) -> bool {
+    logic.is_empty() || logic.eq_ignore_ascii_case("ALL")
+}
+
+/// Whether any assertion mentions an array sort, `select`, or `store`.
+fn assertions_have_array(manager: &TermManager, assertions: &[TermId]) -> bool {
+    let mut stack: Vec<TermId> = assertions.to_vec();
+    let mut seen = FxHashSet::default();
+    while let Some(id) = stack.pop() {
+        if !seen.insert(id) {
+            continue;
+        }
+        let Some(term) = manager.get(id) else {
+            continue;
+        };
+        if matches!(term.kind, TermKind::Select(_, _) | TermKind::Store(_, _, _)) {
+            return true;
+        }
+        if let Some(sort) = manager.sorts.get(term.sort)
+            && matches!(sort.kind, SortKind::Array { .. })
+        {
+            return true;
+        }
+        super::term_walk::collect_structural_children(&term.kind, &mut stack);
+    }
+    false
+}
+
+/// Whether any assertion involves Int-sorted arithmetic (vars, selects, consts
+/// under arith ops). Used to prefer the NIA backend over pure NRA under `ALL`.
+fn assertions_have_int_arith(manager: &TermManager, assertions: &[TermId]) -> bool {
+    let int_sort = manager.sorts.int_sort;
+    let mut stack: Vec<TermId> = assertions.to_vec();
+    let mut seen = FxHashSet::default();
+    while let Some(id) = stack.pop() {
+        if !seen.insert(id) {
+            continue;
+        }
+        let Some(term) = manager.get(id) else {
+            continue;
+        };
+        if term.sort == int_sort
+            && matches!(
+                term.kind,
+                TermKind::Var(_)
+                    | TermKind::Select(_, _)
+                    | TermKind::IntConst(_)
+                    | TermKind::Add(_)
+                    | TermKind::Mul(_)
+                    | TermKind::Sub(_, _)
+                    | TermKind::Neg(_)
+                    | TermKind::Div(_, _)
+                    | TermKind::Mod(_, _)
+            )
+        {
+            return true;
+        }
+        super::term_walk::collect_structural_children(&term.kind, &mut stack);
+    }
+    false
 }
 
 /// Convert a `BigRational` into a Real-sorted constant term.

--- a/oxiz-solver/src/solver/check_nlsat.rs
+++ b/oxiz-solver/src/solver/check_nlsat.rs
@@ -14,13 +14,16 @@
 
 #[allow(unused_imports)]
 use crate::prelude::*;
-use num_rational::Rational64;
+use num_bigint::BigInt;
+use num_rational::{BigRational, Rational64};
 use num_traits::{One, ToPrimitive, Zero};
 use oxiz_core::ast::{TermId, TermKind, TermManager};
-use oxiz_theories::nlsat::{NlDispatchResult, dispatch_nia_constraints, dispatch_nra_constraints};
+use oxiz_theories::nlsat::{
+    NlDispatchResult, NlSatModel, dispatch_nia_constraints, dispatch_nra_constraints,
+};
 
 use super::Solver;
-use super::types::SolverResult;
+use super::types::{Model, SolverResult};
 
 /// A polynomial atom extracted from an assertion.
 /// Represents: `coeff * square_term OP constant`
@@ -62,29 +65,52 @@ impl Solver {
     /// `SolverResult` when the solver is conclusive, or `None` to fall
     /// through to CDCL(T).
     ///
+    /// On `Sat`, installs a concrete model from the NL solver so subsequent
+    /// `(get-model)` / `(get-value …)` queries succeed.
+    ///
     /// Handles:
     /// - `x * y`, `x * y * z` (products of distinct variables)
     /// - `x * x` (squares / higher powers via repeated multiplication)
     /// - `(x + 1) * (y - 2)` (products of linear expressions)
-    pub(super) fn dispatch_nl_solver(&self, manager: &TermManager) -> Option<SolverResult> {
+    pub(super) fn dispatch_nl_solver(&mut self, manager: &mut TermManager) -> Option<SolverResult> {
         let logic = self.logic.as_deref()?;
 
         let is_nia = logic.contains("NIA") || (logic.contains("NIRA") && !logic.contains("NRA"));
         let is_nra = logic.contains("NRA") && !is_nia;
 
-        if is_nia {
-            dispatch_nia_constraints(&self.assertions, manager, true).map(|r| match r {
-                NlDispatchResult::Sat => SolverResult::Sat,
-                NlDispatchResult::Unsat => SolverResult::Unsat,
-            })
+        let result = if is_nia {
+            dispatch_nia_constraints(&self.assertions, manager, true)
         } else if is_nra {
-            dispatch_nra_constraints(&self.assertions, manager).map(|r| match r {
-                NlDispatchResult::Sat => SolverResult::Sat,
-                NlDispatchResult::Unsat => SolverResult::Unsat,
-            })
+            dispatch_nra_constraints(&self.assertions, manager)
         } else {
             None
+        }?;
+
+        match result {
+            NlDispatchResult::Sat(nl_model) => {
+                self.install_nl_model(nl_model, manager);
+                Some(SolverResult::Sat)
+            }
+            NlDispatchResult::Unsat => Some(SolverResult::Unsat),
         }
+    }
+
+    /// Install an NL-dispatch model into `self.model` for `(get-model)`.
+    fn install_nl_model(&mut self, nl_model: NlSatModel, manager: &mut TermManager) {
+        let mut model = Model::new();
+        for (term, value) in nl_model.assignments {
+            let is_int = manager
+                .get(term)
+                .map(|t| t.sort == manager.sorts.int_sort)
+                .unwrap_or(true);
+            let value_term = if is_int {
+                manager.mk_int(value.to_integer())
+            } else {
+                big_rational_to_real_term(manager, &value)
+            };
+            model.set(term, value_term);
+        }
+        self.model = Some(model);
     }
 
     /// Check nonlinear arithmetic constraints for early UNSAT detection.
@@ -609,6 +635,28 @@ impl Solver {
             }
             _ => None,
         }
+    }
+}
+
+/// Convert a `BigRational` into a Real-sorted constant term.
+///
+/// Prefers an exact `Rational64` when both numerator and denominator fit in
+/// `i64`; otherwise falls back to an integer approximation of the floor
+/// (still a valid Real constant, just less precise for huge values).
+fn big_rational_to_real_term(manager: &mut TermManager, value: &BigRational) -> TermId {
+    let n = value.numer();
+    let d = value.denom();
+    if let (Some(ni), Some(di)) = (n.to_i64(), d.to_i64()) {
+        if di != 0 {
+            return manager.mk_real(Rational64::new(ni, di));
+        }
+    }
+    // Fallback: integer part only.
+    let approx: BigInt = value.to_integer();
+    if let Some(v) = approx.to_i64() {
+        manager.mk_real(Rational64::from_integer(v))
+    } else {
+        manager.mk_real(Rational64::from_integer(0))
     }
 }
 

--- a/oxiz-solver/src/solver/encode.rs
+++ b/oxiz-solver/src/solver/encode.rs
@@ -497,6 +497,14 @@ impl Solver {
 
     /// Assert a term
     pub fn assert(&mut self, term: TermId, manager: &mut TermManager) {
+        // Grammar-driven arithmetic purification: under `+,-,*,div,mod` and
+        // arith comparisons, replace non-arith numeric subterms (select, UF
+        // apps, …) with fresh constants and conjoin interface equalities.
+        // NIA/LIA then see only pure polynomials; array/EUF own the foreign
+        // structure via `c = select(...)`.
+        let purified = super::purify_arith::purify_assertion(term, manager, &mut self.arith_purify);
+        let term = purified.term;
+
         let index = self.assertions.len();
         self.assertions.push(term);
         self.trail.push(TrailOp::AssertionAdded { index });

--- a/oxiz-solver/src/solver/encode_guards.rs
+++ b/oxiz-solver/src/solver/encode_guards.rs
@@ -76,6 +76,21 @@ impl Solver {
             };
             match &node.kind {
                 TermKind::Div(_, _) | TermKind::Mod(_, _) => return true,
+                // Walk into `ite` so nonlinear products nested under ite are
+                // visible (previously CDCL returned spurious sat on QF_NIA).
+                // Do not unconditionally flag ite itself — constant table ites
+                // are handled by NIA case-split / expansion.
+                TermKind::Ite(c, t, e) => {
+                    stack.push(*c);
+                    stack.push(*t);
+                    stack.push(*e);
+                }
+                TermKind::Let { bindings, body } => {
+                    for &(_, v) in bindings.iter() {
+                        stack.push(v);
+                    }
+                    stack.push(*body);
+                }
                 TermKind::IntConst(n) if n.to_i64().is_none() => return true,
                 TermKind::BitVecConst { value, .. } if value.to_i64().is_none() => return true,
                 TermKind::Mul(args) => {
@@ -95,11 +110,21 @@ impl Solver {
                         stack.push(a);
                     }
                 }
-                TermKind::Sub(a, b) => {
+                TermKind::Sub(a, b)
+                | TermKind::Eq(a, b)
+                | TermKind::Lt(a, b)
+                | TermKind::Le(a, b)
+                | TermKind::Gt(a, b)
+                | TermKind::Ge(a, b) => {
                     stack.push(*a);
                     stack.push(*b);
                 }
-                TermKind::Neg(a) => stack.push(*a),
+                TermKind::Neg(a) | TermKind::Not(a) => stack.push(*a),
+                TermKind::And(args) | TermKind::Or(args) => {
+                    for &a in args {
+                        stack.push(a);
+                    }
+                }
                 _ => {}
             }
         }
@@ -126,6 +151,11 @@ impl Solver {
                 | TermKind::Select(_, _)
                 | TermKind::Div(_, _)
                 | TermKind::Mod(_, _) => return true,
+                TermKind::Ite(c, t, e) => {
+                    stack.push(*c);
+                    stack.push(*t);
+                    stack.push(*e);
+                }
                 TermKind::Add(args) | TermKind::Mul(args) => {
                     for &a in args {
                         stack.push(a);

--- a/oxiz-solver/src/solver/mod.rs
+++ b/oxiz-solver/src/solver/mod.rs
@@ -14,6 +14,7 @@ pub(super) mod encode;
 pub(super) mod encode_guards;
 pub(super) mod model_builder;
 pub(super) mod pigeonhole;
+pub(super) mod purify_arith;
 pub(super) mod term_walk;
 pub(super) mod theory_bv_encode;
 pub(super) mod theory_manager;
@@ -148,6 +149,9 @@ pub struct Solver {
     /// most once, which makes the in-loop refinement in `check` terminate: every
     /// refinement round either adds a strictly new instance or reports `Sat`.
     pub(super) array_axiom_instances: FxHashSet<TermId>,
+    /// Arithmetic purification state (fresh interface constants for foreign
+    /// numeric subterms under arith contexts).
+    pub(super) arith_purify: purify_arith::PurifyState,
 }
 
 /// Maximum term-nesting depth the recursive Tseitin encoder will descend
@@ -250,6 +254,7 @@ impl Solver {
             encode_depth_exceeded: false,
             has_array_ops: false,
             array_axiom_instances: FxHashSet::default(),
+            arith_purify: purify_arith::PurifyState::new(),
         }
     }
 

--- a/oxiz-solver/src/solver/mod.rs
+++ b/oxiz-solver/src/solver/mod.rs
@@ -558,6 +558,9 @@ impl Solver {
         }
 
         if self.assertions.is_empty() {
+            // Empty assertion set is vacuously SAT — install an empty model so
+            // `(get-model)` returns `(model)` rather than "No model available".
+            self.model = Some(Model::new());
             return SolverResult::Sat;
         }
 

--- a/oxiz-solver/src/solver/purify_arith.rs
+++ b/oxiz-solver/src/solver/purify_arith.rs
@@ -406,7 +406,7 @@ mod tests {
             .into_iter()
             .map(|t| purify_assertion(t, &mut tm, &mut state).term)
             .collect();
-        let r = dispatch_nia_constraints(&purified, &tm, true);
+        let r = dispatch_nia_constraints(&purified, &mut tm, true);
         assert_eq!(
             r,
             Some(NlDispatchResult::Unsat),

--- a/oxiz-solver/src/solver/purify_arith.rs
+++ b/oxiz-solver/src/solver/purify_arith.rs
@@ -1,0 +1,443 @@
+//! Grammar-driven arithmetic purification.
+//!
+//! Under arithmetic contexts (`+`, `-`, `*`, `div`, `mod`, comparisons), any
+//! subterm whose head is **not** an arithmetic constructor is replaced by a
+//! fresh constant of the same numeric sort, and an interface equality
+//! `fresh = original` is recorded.
+//!
+//! ```text
+//! ArithCtor  ::= IntConst | RealConst | Var
+//!              | Neg | Add | Sub | Mul | Div | Mod
+//!              | Ite   (condition purified as formula; branches as arith)
+//!
+//! Foreign    ::= Select | Store | Apply | …  (anything else with numeric sort)
+//! ```
+//!
+//! This is the standard SMT purification step: the arithmetic solver only ever
+//! sees pure polynomials over variables; array/UF theories own the foreign
+//! structure via the interface equalities.
+
+use oxiz_core::ast::{TermId, TermKind, TermManager};
+use oxiz_core::sort::SortId;
+use rustc_hash::FxHashMap;
+
+/// Result of purifying one assertion.
+#[derive(Debug)]
+pub struct PurifyResult {
+    /// Assertion rewritten so every arith context is pure.
+    pub term: TermId,
+    /// Interface equalities `(fresh_const, original_foreign_term)`.
+    #[allow(dead_code)]
+    pub interface: Vec<(TermId, TermId)>,
+}
+
+/// Fresh-name counter shared across assertions in one solver.
+#[derive(Debug, Default)]
+pub struct PurifyState {
+    next_id: u64,
+    /// Memo: original foreign term → fresh constant (stable across asserts).
+    foreign_to_fresh: FxHashMap<TermId, TermId>,
+}
+
+impl PurifyState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+fn is_numeric_sort(manager: &TermManager, sort: SortId) -> bool {
+    sort == manager.sorts.int_sort || sort == manager.sorts.real_sort
+}
+
+fn is_array_sort(manager: &TermManager, sort: SortId) -> bool {
+    manager
+        .sorts
+        .get(sort)
+        .is_some_and(|s| matches!(s.kind, oxiz_core::sort::SortKind::Array { .. }))
+}
+
+/// Head is a pure arithmetic constructor (operands still may need purification).
+///
+/// `Ite` is kept as a constructor so nested table-style definitions remain
+/// available to the boolean layer; its condition is purified as a formula and
+/// its branches as arith. Foreign leaves under those branches (select, apply)
+/// still become interface constants.
+fn is_arith_constructor(kind: &TermKind) -> bool {
+    matches!(
+        kind,
+        TermKind::IntConst(_)
+            | TermKind::RealConst(_)
+            | TermKind::Var(_)
+            | TermKind::Neg(_)
+            | TermKind::Add(_)
+            | TermKind::Sub(_, _)
+            | TermKind::Mul(_)
+            | TermKind::Div(_, _)
+            | TermKind::Mod(_, _)
+            | TermKind::Ite(_, _, _)
+    )
+}
+
+/// Purify `term` for use as a top-level assertion.
+pub fn purify_assertion(
+    term: TermId,
+    manager: &mut TermManager,
+    state: &mut PurifyState,
+) -> PurifyResult {
+    let mut interface = Vec::new();
+    let rewritten = purify_rec(term, manager, state, &mut interface, false);
+    // Conjoin interface equalities so array/EUF see `c = select(...)` etc.
+    if interface.is_empty() {
+        return PurifyResult {
+            term: rewritten,
+            interface,
+        };
+    }
+    let mut parts = vec![rewritten];
+    for &(fresh, orig) in &interface {
+        parts.push(manager.mk_eq(fresh, orig));
+    }
+    let term = if parts.len() == 1 {
+        parts[0]
+    } else {
+        manager.mk_and(parts)
+    };
+    PurifyResult { term, interface }
+}
+
+fn purify_rec(
+    term: TermId,
+    manager: &mut TermManager,
+    state: &mut PurifyState,
+    interface: &mut Vec<(TermId, TermId)>,
+    under_arith: bool,
+) -> TermId {
+    let Some(node) = manager.get(term) else {
+        return term;
+    };
+    let kind = node.kind.clone();
+    let sort = node.sort;
+
+    // Under arith, a numeric non-constructor is a foreign leaf → fresh const.
+    if under_arith && is_numeric_sort(manager, sort) && !is_arith_constructor(&kind) {
+        return allocate_fresh(term, sort, manager, state, interface);
+    }
+
+    match kind {
+        // --- leaves ---
+        TermKind::IntConst(_)
+        | TermKind::RealConst(_)
+        | TermKind::Var(_)
+        | TermKind::True
+        | TermKind::False
+        | TermKind::StringLit(_)
+        | TermKind::BitVecConst { .. } => term,
+
+        // --- arithmetic constructors: stay under arith ---
+        TermKind::Neg(a) => {
+            let a = purify_rec(a, manager, state, interface, true);
+            manager.mk_neg(a)
+        }
+        TermKind::Add(args) => {
+            let args: Vec<TermId> = args
+                .iter()
+                .map(|&a| purify_rec(a, manager, state, interface, true))
+                .collect();
+            manager.mk_add(args)
+        }
+        TermKind::Mul(args) => {
+            let args: Vec<TermId> = args
+                .iter()
+                .map(|&a| purify_rec(a, manager, state, interface, true))
+                .collect();
+            manager.mk_mul(args)
+        }
+        TermKind::Sub(a, b) => {
+            let a = purify_rec(a, manager, state, interface, true);
+            let b = purify_rec(b, manager, state, interface, true);
+            manager.mk_sub(a, b)
+        }
+        TermKind::Div(a, b) => {
+            let a = purify_rec(a, manager, state, interface, true);
+            let b = purify_rec(b, manager, state, interface, true);
+            manager.mk_div(a, b)
+        }
+        TermKind::Mod(a, b) => {
+            let a = purify_rec(a, manager, state, interface, true);
+            let b = purify_rec(b, manager, state, interface, true);
+            manager.mk_mod(a, b)
+        }
+        TermKind::Ite(c, t, e) => {
+            // Outside arith: keep ite, purify children in their contexts.
+            // (Under arith, ite is handled as a foreign leaf above.)
+            let c = purify_rec(c, manager, state, interface, false);
+            let branch_arith = under_arith || is_numeric_sort(manager, sort);
+            let t = purify_rec(t, manager, state, interface, branch_arith);
+            let e = purify_rec(e, manager, state, interface, branch_arith);
+            manager.mk_ite(c, t, e)
+        }
+
+        // --- comparisons: operands enter arith ---
+        TermKind::Eq(a, b) => {
+            let a_sort = manager.get(a).map(|t| t.sort);
+            let b_sort = manager.get(b).map(|t| t.sort);
+            let numeric = a_sort.is_some_and(|s| is_numeric_sort(manager, s))
+                || b_sort.is_some_and(|s| is_numeric_sort(manager, s));
+            // Array equalities stay outside arith (no purification of store chains).
+            let array_eq = a_sort.is_some_and(|s| is_array_sort(manager, s))
+                || b_sort.is_some_and(|s| is_array_sort(manager, s));
+            if array_eq {
+                // Still purify nested numeric subterms in indices if any appear
+                // only inside; store trees themselves are left intact.
+                return term;
+            }
+            let a = purify_rec(a, manager, state, interface, numeric);
+            let b = purify_rec(b, manager, state, interface, numeric);
+            manager.mk_eq(a, b)
+        }
+        TermKind::Lt(a, b) => {
+            let a = purify_rec(a, manager, state, interface, true);
+            let b = purify_rec(b, manager, state, interface, true);
+            manager.mk_lt(a, b)
+        }
+        TermKind::Le(a, b) => {
+            let a = purify_rec(a, manager, state, interface, true);
+            let b = purify_rec(b, manager, state, interface, true);
+            manager.mk_le(a, b)
+        }
+        TermKind::Gt(a, b) => {
+            let a = purify_rec(a, manager, state, interface, true);
+            let b = purify_rec(b, manager, state, interface, true);
+            manager.mk_gt(a, b)
+        }
+        TermKind::Ge(a, b) => {
+            let a = purify_rec(a, manager, state, interface, true);
+            let b = purify_rec(b, manager, state, interface, true);
+            manager.mk_ge(a, b)
+        }
+
+        // --- boolean structure ---
+        TermKind::Not(a) => {
+            let a = purify_rec(a, manager, state, interface, false);
+            manager.mk_not(a)
+        }
+        TermKind::And(args) => {
+            let args: Vec<TermId> = args
+                .iter()
+                .map(|&a| purify_rec(a, manager, state, interface, false))
+                .collect();
+            manager.mk_and(args)
+        }
+        TermKind::Or(args) => {
+            let args: Vec<TermId> = args
+                .iter()
+                .map(|&a| purify_rec(a, manager, state, interface, false))
+                .collect();
+            manager.mk_or(args)
+        }
+        TermKind::Xor(a, b) => {
+            let a = purify_rec(a, manager, state, interface, false);
+            let b = purify_rec(b, manager, state, interface, false);
+            manager.mk_xor(a, b)
+        }
+        TermKind::Implies(a, b) => {
+            let a = purify_rec(a, manager, state, interface, false);
+            let b = purify_rec(b, manager, state, interface, false);
+            manager.mk_implies(a, b)
+        }
+        TermKind::Distinct(args) => {
+            let args: Vec<TermId> = args
+                .iter()
+                .map(|&a| {
+                    let s = manager.get(a).map(|t| t.sort);
+                    let num = s.is_some_and(|s| is_numeric_sort(manager, s));
+                    purify_rec(a, manager, state, interface, num)
+                })
+                .collect();
+            manager.mk_distinct(args)
+        }
+
+        // Foreign / other: if numeric under arith already handled; else leave.
+        _ => term,
+    }
+}
+
+fn allocate_fresh(
+    original: TermId,
+    sort: SortId,
+    manager: &mut TermManager,
+    state: &mut PurifyState,
+    interface: &mut Vec<(TermId, TermId)>,
+) -> TermId {
+    if let Some(&f) = state.foreign_to_fresh.get(&original) {
+        // Ensure this assertion's interface list mentions it (for callers that
+        // only look at the per-assert interface vec).
+        if !interface.iter().any(|(c, o)| *c == f && *o == original) {
+            interface.push((f, original));
+        }
+        return f;
+    }
+    let name = format!("$p{}", state.next_id);
+    state.next_id += 1;
+    let fresh = manager.mk_var(&name, sort);
+    state.foreign_to_fresh.insert(original, fresh);
+    interface.push((fresh, original));
+    fresh
+}
+
+/// True when a top-level assertion is purely array/UF structure (not arithmetic).
+#[allow(dead_code)]
+pub fn is_array_structural_assertion(term: TermId, manager: &TermManager) -> bool {
+    let Some(t) = manager.get(term) else {
+        return false;
+    };
+    match &t.kind {
+        TermKind::Eq(a, b) => {
+            let as_ = manager.get(*a).map(|x| x.sort);
+            let bs = manager.get(*b).map(|x| x.sort);
+            as_.is_some_and(|s| is_array_sort(manager, s))
+                || bs.is_some_and(|s| is_array_sort(manager, s))
+        }
+        TermKind::And(args) => args
+            .iter()
+            .all(|&a| is_array_structural_assertion(a, manager)),
+        _ => false,
+    }
+}
+
+/// True when atom is an interface naming `var = foreign` (or swapped).
+#[allow(dead_code)]
+pub fn is_interface_equality(term: TermId, manager: &TermManager) -> bool {
+    let Some(t) = manager.get(term) else {
+        return false;
+    };
+    let TermKind::Eq(a, b) = &t.kind else {
+        return false;
+    };
+    is_var_like(manager, *a) && is_foreign_numeric(manager, *b)
+        || is_var_like(manager, *b) && is_foreign_numeric(manager, *a)
+}
+
+fn is_var_like(manager: &TermManager, t: TermId) -> bool {
+    manager
+        .get(t)
+        .is_some_and(|n| matches!(n.kind, TermKind::Var(_)))
+}
+
+fn is_foreign_numeric(manager: &TermManager, t: TermId) -> bool {
+    let Some(n) = manager.get(t) else {
+        return false;
+    };
+    if !is_numeric_sort(manager, n.sort) {
+        return false;
+    }
+    !is_arith_constructor(&n.kind)
+        || matches!(
+            n.kind,
+            TermKind::Select(_, _) | TermKind::Apply { .. } | TermKind::Store(_, _, _)
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxiz_core::ast::TermManager;
+    use oxiz_theories::nlsat::{NlDispatchResult, dispatch_nia_constraints};
+
+    #[test]
+    fn purifies_select_product() {
+        let mut tm = TermManager::new();
+        let int_s = tm.sorts.int_sort;
+        let arr_s = tm.sorts.array(int_s, int_s);
+        let a = tm.mk_var("A", arr_s);
+        let b = tm.mk_var("B", arr_s);
+        let i = tm.mk_var("i", int_s);
+        let j = tm.mk_var("j", int_s);
+        let sa = tm.mk_select(a, i);
+        let sb = tm.mk_select(b, j);
+        let prod = tm.mk_mul(vec![sa, sb]);
+        let six = tm.mk_int(6);
+        let eq = tm.mk_eq(prod, six);
+
+        let mut state = PurifyState::new();
+        let r = purify_assertion(eq, &mut tm, &mut state);
+        assert_eq!(r.interface.len(), 2, "two selects → two interface vars");
+        assert!(
+            !term_has_select_under_mul(r.term, &tm),
+            "arith product must be pure after purification"
+        );
+    }
+
+    #[test]
+    fn purified_select_box_unsat_via_nia() {
+        let mut tm = TermManager::new();
+        let int_s = tm.sorts.int_sort;
+        let arr_s = tm.sorts.array(int_s, int_s);
+        let a = tm.mk_var("A", arr_s);
+        let b = tm.mk_var("B", arr_s);
+        let i = tm.mk_var("i", int_s);
+        let j = tm.mk_var("j", int_s);
+        let sa = tm.mk_select(a, i);
+        let sb = tm.mk_select(b, j);
+        let one = tm.mk_int(1);
+        let three = tm.mk_int(3);
+        let seven = tm.mk_int(7);
+        let ge_a = tm.mk_ge(sa, one);
+        let le_a = tm.mk_le(sa, three);
+        let ge_b = tm.mk_ge(sb, one);
+        let le_b = tm.mk_le(sb, three);
+        let prod = tm.mk_mul(vec![sa, sb]);
+        let eq_prod = tm.mk_eq(prod, seven);
+        let raw = [ge_a, le_a, ge_b, le_b, eq_prod];
+        let mut state = PurifyState::new();
+        let purified: Vec<_> = raw
+            .into_iter()
+            .map(|t| purify_assertion(t, &mut tm, &mut state).term)
+            .collect();
+        let r = dispatch_nia_constraints(&purified, &tm, true);
+        assert_eq!(
+            r,
+            Some(NlDispatchResult::Unsat),
+            "purified select box product 7 must be NIA-unsat"
+        );
+    }
+
+    fn term_has_select_under_mul(term: TermId, tm: &TermManager) -> bool {
+        let mut stack = vec![(term, false)];
+        while let Some((id, in_mul)) = stack.pop() {
+            let Some(n) = tm.get(id) else { continue };
+            match &n.kind {
+                TermKind::Mul(args) => {
+                    for &a in args {
+                        stack.push((a, true));
+                    }
+                }
+                TermKind::Select(_, _) if in_mul => return true,
+                TermKind::Add(args) | TermKind::And(args) | TermKind::Or(args) => {
+                    for &a in args {
+                        stack.push((a, in_mul));
+                    }
+                }
+                TermKind::Eq(a, b)
+                | TermKind::Sub(a, b)
+                | TermKind::Div(a, b)
+                | TermKind::Mod(a, b)
+                | TermKind::Lt(a, b)
+                | TermKind::Le(a, b)
+                | TermKind::Gt(a, b)
+                | TermKind::Ge(a, b) => {
+                    stack.push((*a, in_mul));
+                    stack.push((*b, in_mul));
+                }
+                TermKind::Neg(a) | TermKind::Not(a) => stack.push((*a, in_mul)),
+                TermKind::Ite(c, a, b) => {
+                    stack.push((*c, false));
+                    stack.push((*a, in_mul));
+                    stack.push((*b, in_mul));
+                }
+                _ => {}
+            }
+        }
+        false
+    }
+}

--- a/oxiz-solver/src/solver/purify_arith.rs
+++ b/oxiz-solver/src/solver/purify_arith.rs
@@ -75,6 +75,7 @@ fn is_arith_constructor(kind: &TermKind) -> bool {
             | TermKind::Div(_, _)
             | TermKind::Mod(_, _)
             | TermKind::Ite(_, _, _)
+            | TermKind::Let { .. }
     )
 }
 
@@ -169,12 +170,23 @@ fn purify_rec(
         }
         TermKind::Ite(c, t, e) => {
             // Outside arith: keep ite, purify children in their contexts.
-            // (Under arith, ite is handled as a foreign leaf above.)
+            // (Under arith with non-constructor path already handled above —
+            // ite *is* a constructor so we keep structure.)
             let c = purify_rec(c, manager, state, interface, false);
             let branch_arith = under_arith || is_numeric_sort(manager, sort);
             let t = purify_rec(t, manager, state, interface, branch_arith);
             let e = purify_rec(e, manager, state, interface, branch_arith);
             manager.mk_ite(c, t, e)
+        }
+        TermKind::Let { bindings, body } => {
+            // `let` is transparent naming. The SMT-LIB parser usually inlines
+            // names into `body` already; still purify binding values and body
+            // so selects under a let inside `*` become interface constants
+            // rather than collapsing the whole let to one unbound fresh var.
+            for &(_, val) in bindings.iter() {
+                let _ = purify_rec(val, manager, state, interface, under_arith);
+            }
+            purify_rec(body, manager, state, interface, under_arith)
         }
 
         // --- comparisons: operands enter arith ---

--- a/oxiz-solver/tests/nlsat_integration.rs
+++ b/oxiz-solver/tests/nlsat_integration.rs
@@ -84,6 +84,77 @@ fn test_nia_sat_provides_get_model() {
     assert_eq!(y_val, expected_y, "y must equal 2*x");
 }
 
+/// Under `(set-logic ALL)`, nonlinear integer formulas must still engage the
+/// NIA dispatch (formula-shape auto-detect) rather than falling through to
+/// an honest `unknown`.
+#[test]
+fn test_all_logic_nia_auto_detect_sat() {
+    let mut ctx = Context::new();
+    ctx.set_logic("ALL");
+
+    let int_sort = ctx.terms.sorts.int_sort;
+    let x = ctx.declare_const("x", int_sort);
+    let square = ctx.terms.mk_mul(vec![x, x]);
+    let four = ctx.terms.mk_int(4);
+    let eq = ctx.terms.mk_eq(square, four);
+    ctx.assert(eq);
+
+    assert_eq!(
+        ctx.check_sat(),
+        SolverResult::Sat,
+        "ALL + x*x=4 must auto-detect NIA and return sat"
+    );
+    let model = ctx.get_model().expect("model after sat under ALL");
+    let x_val = model
+        .iter()
+        .find(|(n, _, _)| n == "x")
+        .map(|(_, _, v)| v.as_str())
+        .expect("x in model");
+    assert!(x_val == "2" || x_val == "-2", "x must be ±2, got {x_val}");
+}
+
+/// Array + nonlinear product under `ALL` is QF_ANIA by shape: must decide
+/// sat just like an explicit `(set-logic QF_ANIA)`.
+#[test]
+fn test_all_logic_ania_auto_detect_sat() {
+    let source = r#"
+        (set-logic ALL)
+        (declare-const A (Array Int Int))
+        (declare-const i Int)
+        (declare-const j Int)
+        (assert (= (select A i) 3))
+        (assert (= (select A j) 4))
+        (assert (= (* (select A i) (select A j)) 12))
+        (check-sat)
+    "#;
+    let mut ctx = Context::new();
+    let outputs = ctx.execute_script(source).expect("script");
+    assert!(
+        outputs.iter().any(|l| l.trim() == "sat"),
+        "ALL + array×select product must auto-detect ANIA, got {outputs:?}"
+    );
+}
+
+/// Pure-real nonlinear under `ALL` should engage NRA, not be stuck on unknown.
+#[test]
+fn test_all_logic_nra_auto_detect_sat() {
+    let mut ctx = Context::new();
+    ctx.set_logic("ALL");
+
+    let real_sort = ctx.terms.sorts.real_sort;
+    let x = ctx.declare_const("x", real_sort);
+    let square = ctx.terms.mk_mul(vec![x, x]);
+    let four = ctx.terms.mk_real(num_rational::Rational64::from_integer(4));
+    let eq = ctx.terms.mk_eq(square, four);
+    ctx.assert(eq);
+
+    assert_eq!(
+        ctx.check_sat(),
+        SolverResult::Sat,
+        "ALL + real x*x=4 must auto-detect NRA and return sat"
+    );
+}
+
 #[test]
 fn test_nia_x_squared_eq_3_unsat() {
     // x * x = 3 → UNSAT (3 is not a perfect square)

--- a/oxiz-solver/tests/nlsat_integration.rs
+++ b/oxiz-solver/tests/nlsat_integration.rs
@@ -33,6 +33,57 @@ fn test_nia_x_squared_eq_4_sat() {
     );
 }
 
+/// Regression: NL dispatch used to return `Sat` without installing a model, so
+/// `(get-model)` emitted `(error "No model available")` after a successful
+/// `check-sat`. The model must be present and assign `x` to ±2.
+#[test]
+fn test_nia_sat_provides_get_model() {
+    let mut ctx = Context::new();
+    ctx.set_logic("QF_NIA");
+
+    let int_sort = ctx.terms.sorts.int_sort;
+    let x = ctx.declare_const("x", int_sort);
+    let y = ctx.declare_const("y", int_sort);
+    let square = ctx.terms.mk_mul(vec![x, x]);
+    let four = ctx.terms.mk_int(4);
+    let eq_sq = ctx.terms.mk_eq(square, four);
+    ctx.assert(eq_sq);
+    let two = ctx.terms.mk_int(2);
+    let two_x = ctx.terms.mk_mul(vec![two, x]);
+    let eq_y = ctx.terms.mk_eq(y, two_x);
+    ctx.assert(eq_y);
+
+    assert_eq!(ctx.check_sat(), SolverResult::Sat);
+
+    let model = ctx
+        .get_model()
+        .expect("Sat from NL dispatch must install a model for get-model");
+    let formatted = ctx.format_model();
+    assert!(
+        !formatted.contains("No model available"),
+        "get-model must not error after sat, got: {formatted}"
+    );
+
+    let mut x_val = None;
+    let mut y_val = None;
+    for (name, _sort, value) in &model {
+        match name.as_str() {
+            "x" => x_val = Some(value.clone()),
+            "y" => y_val = Some(value.clone()),
+            _ => {}
+        }
+    }
+    let x_val = x_val.expect("model must assign x");
+    let y_val = y_val.expect("model must assign y");
+    // x ∈ {2, -2}, y = 2x
+    assert!(
+        x_val == "2" || x_val == "-2",
+        "x must be ±2, got {x_val}"
+    );
+    let expected_y = if x_val == "2" { "4" } else { "-4" };
+    assert_eq!(y_val, expected_y, "y must equal 2*x");
+}
+
 #[test]
 fn test_nia_x_squared_eq_3_unsat() {
     // x * x = 3 → UNSAT (3 is not a perfect square)

--- a/oxiz-solver/tests/qf_ania_ce.rs
+++ b/oxiz-solver/tests/qf_ania_ce.rs
@@ -1,0 +1,70 @@
+//! QF_ANIA fixtures: nonlinear products over array `select` terms.
+use oxiz_solver::{Context, SolverResult};
+use std::path::{Path, PathBuf};
+
+fn fixture_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../bench/qf_ania_ce")
+}
+
+fn run_smt2(path: &Path) -> SolverResult {
+    let source = std::fs::read_to_string(path).unwrap();
+    let mut ctx = Context::new();
+    match ctx.execute_script(&source) {
+        Ok(outputs) => {
+            for line in outputs.iter().rev() {
+                match line.trim() {
+                    "sat" => return SolverResult::Sat,
+                    "unsat" => return SolverResult::Unsat,
+                    "unknown" => return SolverResult::Unknown,
+                    _ => {}
+                }
+            }
+            SolverResult::Unknown
+        }
+        Err(e) => panic!("{}: {e}", path.display()),
+    }
+}
+
+fn expected(path: &Path) -> SolverResult {
+    let source = std::fs::read_to_string(path).unwrap();
+    for line in source.lines().take(8) {
+        let l = line.to_lowercase();
+        if l.contains("expected:") {
+            if l.contains("unsat") {
+                return SolverResult::Unsat;
+            }
+            if l.contains("sat") {
+                return SolverResult::Sat;
+            }
+        }
+    }
+    panic!("{}: missing expected", path.display());
+}
+
+#[test]
+fn qf_ania_ce_all_fixtures() {
+    let dir = fixture_dir();
+    assert!(dir.is_dir(), "missing {}", dir.display());
+    let mut paths: Vec<_> = std::fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|x| x == "smt2"))
+        .collect();
+    paths.sort();
+    let mut failures = Vec::new();
+    let mut exact = 0usize;
+    for path in &paths {
+        let name = path.file_name().unwrap().to_string_lossy().into_owned();
+        let exp = expected(path);
+        let actual = run_smt2(path);
+        eprintln!("  {name}: expected={exp:?} got={actual:?}");
+        if actual == exp {
+            exact += 1;
+        } else {
+            failures.push(format!("{name}: expected {exp:?}, got {actual:?}"));
+        }
+    }
+    eprintln!("qf_ania_ce: {exact}/{} exact", paths.len());
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}

--- a/oxiz-solver/tests/qf_nia_ce.rs
+++ b/oxiz-solver/tests/qf_nia_ce.rs
@@ -1,0 +1,124 @@
+//! QF_NIA counterexample fixture suite (`bench/qf_nia_ce/`).
+//!
+//! Pure math SMT-LIB2 instances. Each file carries `;; expected: sat|unsat`.
+//! Every fixture is checked for an exact match — no gap allowlist.
+
+use oxiz_solver::{Context, SolverResult};
+use std::path::{Path, PathBuf};
+
+fn fixture_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../bench/qf_nia_ce")
+}
+
+fn run_smt2(path: &Path) -> SolverResult {
+    let source =
+        std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let mut ctx = Context::new();
+    match ctx.execute_script(&source) {
+        Ok(outputs) => {
+            for line in outputs.iter().rev() {
+                match line.trim() {
+                    "sat" => return SolverResult::Sat,
+                    "unsat" => return SolverResult::Unsat,
+                    "unknown" => return SolverResult::Unknown,
+                    _ => {}
+                }
+            }
+            SolverResult::Unknown
+        }
+        Err(e) => panic!("execute {}: {e}", path.display()),
+    }
+}
+
+fn expected_from_file(path: &Path) -> Option<SolverResult> {
+    let source = std::fs::read_to_string(path).ok()?;
+    for line in source.lines().take(12) {
+        let lower = line.to_lowercase();
+        if !(lower.contains("expected:") || lower.contains("expected :")) {
+            continue;
+        }
+        if lower.contains("unsat") {
+            return Some(SolverResult::Unsat);
+        }
+        if lower.contains("unknown") {
+            return Some(SolverResult::Unknown);
+        }
+        if lower.contains("sat") {
+            return Some(SolverResult::Sat);
+        }
+    }
+    None
+}
+
+fn collect_fixtures() -> Vec<PathBuf> {
+    let dir = fixture_dir();
+    assert!(dir.is_dir(), "missing fixture dir {}", dir.display());
+    let mut paths: Vec<_> = std::fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("read_dir {}: {e}", dir.display()))
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|x| x == "smt2"))
+        .collect();
+    paths.sort();
+    assert!(!paths.is_empty(), "no .smt2 in {}", dir.display());
+    paths
+}
+
+fn classify(exp: SolverResult, actual: SolverResult) -> &'static str {
+    match (exp, actual) {
+        (e, a) if e == a => "ok",
+        (SolverResult::Sat, SolverResult::Unsat) | (SolverResult::Unsat, SolverResult::Sat) => {
+            "wrong"
+        }
+        (_, SolverResult::Unknown) => "unknown",
+        (SolverResult::Unknown, _) => "unexpected_decisive",
+        _ => "mismatch",
+    }
+}
+
+#[test]
+fn qf_nia_ce_all_fixtures() {
+    let mut rows = Vec::new();
+    let mut exact = 0usize;
+    let mut wrong = 0usize;
+    let mut unknown = 0usize;
+    let mut other = 0usize;
+
+    for path in collect_fixtures() {
+        let name = path
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        let exp = expected_from_file(&path)
+            .unwrap_or_else(|| panic!("{name}: missing ;; expected: sat|unsat"));
+        let actual = run_smt2(&path);
+        let tag = classify(exp, actual);
+        match tag {
+            "ok" => exact += 1,
+            "wrong" => wrong += 1,
+            "unknown" => unknown += 1,
+            _ => other += 1,
+        }
+        rows.push((name, exp, actual, tag));
+    }
+
+    let total = rows.len();
+    eprintln!("qf_nia_ce: {exact}/{total} exact  wrong={wrong}  unknown={unknown}  other={other}");
+    for (name, exp, actual, tag) in &rows {
+        eprintln!("  {tag:<10} {name:<40} expected={exp:?} got={actual:?}");
+    }
+
+    let failures: Vec<String> = rows
+        .iter()
+        .filter(|(_, _, _, tag)| *tag != "ok")
+        .map(|(name, exp, actual, tag)| format!("{name}: expected {exp:?}, got {actual:?} [{tag}]"))
+        .collect();
+
+    assert!(
+        failures.is_empty(),
+        "qf_nia_ce: {exact}/{total} exact, {} gap(s):\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}

--- a/oxiz-solver/tests/qf_nia_soundness.rs
+++ b/oxiz-solver/tests/qf_nia_soundness.rs
@@ -1,0 +1,96 @@
+//! QF_NIA soundness: never return sat for integer-unsatisfiable nonlinear formulas.
+//!
+//! Benchmarks referenced by name (not vendored):
+//! - smt-lib/non-incremental/QF_NIA/calypto/problem-000044.cvc.2.smt2
+//! - smt-lib/non-incremental/QF_NIA/UltimateAutomizer/gauss_sum_true-unreach-call.i.smt2
+
+use oxiz_solver::{Context, SolverResult};
+
+fn run(src: &str) -> SolverResult {
+    let mut ctx = Context::new();
+    let out = ctx.execute_script(src).expect("script");
+    out.iter()
+        .rev()
+        .find_map(|l| match l.trim() {
+            "sat" => Some(SolverResult::Sat),
+            "unsat" => Some(SolverResult::Unsat),
+            "unknown" => Some(SolverResult::Unknown),
+            _ => None,
+        })
+        .unwrap_or(SolverResult::Unknown)
+}
+
+/// Classic: x*x = 2 has no integer solution.
+#[test]
+fn square_eq_two_is_unsat() {
+    assert_eq!(
+        run(r#"(set-logic QF_NIA)(declare-const x Int)(assert (= (* x x) 2))(check-sat)"#),
+        SolverResult::Unsat
+    );
+}
+
+/// Nested let/ite industrial pattern (calypto-style). Must not return sat.
+/// Prefer unsat; unknown is an acceptable incomplete answer.
+#[test]
+fn calypto_style_let_ite_product_not_sat() {
+    let src = r#"
+(set-logic QF_NIA)
+(set-info :status unsat)
+(declare-fun P_2 () Bool)
+(declare-fun P_3 () Int)
+(declare-fun P_4 () Int)
+(declare-fun P_5 () Int)
+(declare-fun P_6 () Int)
+(assert (<= 0 P_3))
+(assert (<= P_3 255))
+(assert (<= 0 P_4))
+(assert (<= P_4 1016))
+(assert (<= 0 P_5))
+(assert (<= P_5 127))
+(assert (<= 0 P_6))
+(assert (<= P_6 255))
+(declare-fun dz () Int)
+(declare-fun rz () Int)
+(assert
+ (let ((?v_0 (ite P_2 1 0))
+       (?v_1 (* P_3 P_6)))
+  (let ((?v_5 (= (ite (>= ?v_0 0) ?v_0 (+ ?v_0 2)) 0))
+        (?v_2 (* 1 (- 1))))
+   (let ((?v_3 (- ?v_2 (ite (not (> (ite (< P_4 512) P_4 (- P_4 1024)) 127)) P_5 ?v_2))))
+    (let ((?v_6 (* P_3 (ite (>= ?v_3 0) ?v_3 (+ ?v_3 128)))))
+     (let ((?v_4 (* ?v_6 P_6)))
+      (let ((?v_7 (- ?v_4)))
+       (= (+ (* 134217728 dz) rz)
+          (- (ite (not (< (ite ?v_5 ?v_1 (- ?v_1)) 0)) ?v_4 ?v_7)
+             (ite (not (< (ite ?v_5 ?v_6 (+ (- ?v_2 ?v_6) 1)) 0)) ?v_4 ?v_7))))))))))
+(assert (> rz 0))
+(assert (< rz 134217728))
+(check-sat)
+"#;
+    let r = run(src);
+    assert_ne!(
+        r,
+        SolverResult::Sat,
+        "soundness: calypto-style NIA must not return sat (got {r:?})"
+    );
+}
+
+/// ite wrapping a product: with x=y=0 the product cannot be 1 or 2.
+#[test]
+fn ite_product_zero_unsat() {
+    assert_eq!(
+        run(
+            r#"
+            (set-logic QF_NIA)
+            (declare-const b Bool)
+            (declare-const x Int)
+            (declare-const y Int)
+            (assert (= x 0))
+            (assert (= y 0))
+            (assert (= (* x y) (ite b 1 2)))
+            (check-sat)
+            "#
+        ),
+        SolverResult::Unsat
+    );
+}

--- a/oxiz-theories/src/ania_ground.rs
+++ b/oxiz-theories/src/ania_ground.rs
@@ -1,12 +1,13 @@
-//! Ground QF_ANIA decision for constant store-chains + finite index boxes.
+//! Ground QF_ANIA decision procedure.
 //!
-//! Works on **purified** assertions:
-//! - `A = store(... (as const) d ...)` array definitions
-//! - `c = select(A, i)` interface equalities from arithmetic purification
-//! - pure arithmetic on `c` and index vars
+//! Handles formulas whose arrays are defined by constant `store` towers and
+//! whose free integer variables (indices and similar) lie in finite boxes.
+//! Under each concrete assignment we evaluate the full term DAG — including
+//! nested `select`, `ite`, `abs`-as-ite, and multi-factor products — via
+//! read-over-write on the store maps.
 //!
-//! Free selects (no store def) are out of scope here — pure NIA on interface
-//! constants remains sound for those.
+//! Works on purified assertions (`c = select(A,i)` interfaces + pure arith)
+//! and on residual `ite`/`select` still present under arith after purification.
 
 use crate::nlsat::NlDispatchResult;
 use num_bigint::BigInt;
@@ -15,17 +16,23 @@ use oxiz_core::ast::{TermId, TermKind, TermManager};
 use oxiz_core::sort::SortKind;
 use std::collections::{HashMap, HashSet};
 
-const MAX_INDEX_PRODUCT: u64 = 50_000;
+/// Soft cap on visited leaves (full assignments tried). Pruning usually keeps
+/// real work far below this for constrained formulas.
+const MAX_LEAVES: u64 = 5_000_000;
 
-/// Try to decide ground store + bounded-index ANIA (post-purification shape).
+/// Try to decide ground-store + finite-box ANIA.
 pub fn try_decide_ground_ania(
     assertions: &[TermId],
     manager: &TermManager,
 ) -> Option<NlDispatchResult> {
     let mut arrays: HashMap<TermId, ArrayInterp> = HashMap::new();
-    let mut interfaces: Vec<Interface> = Vec::new(); // c = select(A, idx)
+    let mut interfaces: Vec<Interface> = Vec::new();
+    // `v = t` where `t` is evaluable once indices are bound (nullary define-fun).
+    let mut definitions: Vec<(TermId, TermId)> = Vec::new();
     let mut bounds: HashMap<TermId, (Option<i64>, Option<i64>)> = HashMap::new();
-    let mut arith_atoms: Vec<ArithAtom> = Vec::new();
+    let mut atoms: Vec<Atom> = Vec::new();
+    let mut bool_atoms: Vec<TermId> = Vec::new(); // must eval to true
+    let mut free_ints: HashSet<TermId> = HashSet::new();
 
     for &a in assertions {
         collect_assertion(
@@ -33,109 +40,261 @@ pub fn try_decide_ground_ania(
             manager,
             &mut arrays,
             &mut interfaces,
+            &mut definitions,
             &mut bounds,
-            &mut arith_atoms,
+            &mut atoms,
+            &mut bool_atoms,
+            &mut free_ints,
         )?;
     }
 
-    if arrays.is_empty() || interfaces.is_empty() || arith_atoms.is_empty() {
+    if arrays.is_empty() || (atoms.is_empty() && bool_atoms.is_empty()) {
         return None;
     }
 
-    // Every interface select must read a defined array; index must be var or numeral.
-    let mut index_vars: Vec<TermId> = Vec::new();
+    // Every select (in atoms or interfaces) must read a defined array.
+    for atom in &atoms {
+        ensure_selects_defined(atom.lhs, manager, &arrays)?;
+        ensure_selects_defined(atom.rhs, manager, &arrays)?;
+    }
+    for &b in &bool_atoms {
+        ensure_selects_defined(b, manager, &arrays)?;
+    }
     for iface in &interfaces {
         if !arrays.contains_key(&iface.array) {
             return None;
         }
-        if let Some(v) = as_var(manager, iface.index) {
-            if !index_vars.contains(&v) {
-                index_vars.push(v);
-            }
-        } else if eval_ground_int(iface.index, manager).is_none() {
-            return None;
-        }
+        collect_int_vars(iface.index, manager, &mut free_ints);
+    }
+    for &(_, rhs) in &definitions {
+        ensure_selects_defined(rhs, manager, &arrays)?;
+        collect_int_vars(rhs, manager, &mut free_ints);
     }
 
+    // Index / free int vars need finite boxes.
     let mut domains: Vec<(TermId, i64, i64)> = Vec::new();
-    let mut product: u64 = 1;
-    for &v in &index_vars {
+    for &v in &free_ints {
+        // Skip vars determined by interface selects or definitional eqs.
+        if interfaces.iter().any(|i| i.const_var == v) {
+            continue;
+        }
+        if definitions.iter().any(|(lhs, _)| *lhs == v) {
+            continue;
+        }
         let (lo, hi) = bounds.get(&v).copied().unwrap_or((None, None));
         let lo = lo?;
         let hi = hi?;
         if hi < lo {
             return Some(NlDispatchResult::Unsat);
         }
-        let w = (hi - lo + 1) as u64;
-        product = product.saturating_mul(w);
-        if product > MAX_INDEX_PRODUCT {
-            return None;
-        }
         domains.push((v, lo, hi));
     }
+    // Prefer smaller domains first for stronger early pruning.
+    domains.sort_by_key(|(_, lo, hi)| hi - lo);
 
-    let mut idxs: Vec<i64> = domains.iter().map(|(_, lo, _)| *lo).collect();
-    loop {
-        let mut env: HashMap<TermId, BigInt> = HashMap::new();
-        for (i, &(v, _, _)) in domains.iter().enumerate() {
-            env.insert(v, BigInt::from(idxs[i]));
-        }
-        // Realize each interface const via store evaluation.
-        let mut ok = true;
-        for iface in &interfaces {
-            let idx_val = if let Some(v) = as_var(manager, iface.index) {
-                env.get(&v).cloned().ok_or(())
-            } else {
-                eval_ground_int(iface.index, manager)
-                    .map(BigInt::from)
-                    .ok_or(())
-            };
-            let Ok(idx_val) = idx_val else {
-                ok = false;
-                break;
-            };
-            let Some(i64v) = idx_val.to_i64() else {
-                ok = false;
-                break;
-            };
-            let interp = &arrays[&iface.array];
-            let sel = interp
-                .entries
-                .get(&i64v)
-                .cloned()
-                .unwrap_or_else(|| interp.default.clone());
-            env.insert(iface.const_var, sel);
-        }
-        if ok {
-            let mut cache = HashMap::new();
-            let mut all_hold = true;
-            for atom in &arith_atoms {
-                if !eval_atom(atom, manager, &env, &mut cache) {
-                    all_hold = false;
-                    break;
-                }
-            }
-            if all_hold {
-                return Some(NlDispatchResult::Sat);
-            }
-        }
+    // Recursive search with early pruning: once enough vars are bound to
+    // evaluate an atom, reject partial assignments immediately (critical when
+    // e.g. `(select A i) = c` with sparse table values kills most of 1..N).
+    let mut env = HashMap::new();
+    let mut leaves = 0u64;
+    match search_rec(
+        0,
+        &domains,
+        &interfaces,
+        &definitions,
+        &atoms,
+        &bool_atoms,
+        &arrays,
+        manager,
+        &mut env,
+        &mut leaves,
+    ) {
+        Some(true) => Some(NlDispatchResult::Sat),
+        Some(false) => Some(NlDispatchResult::Unsat),
+        None => None, // exhausted leaf budget
+    }
+}
 
-        if domains.is_empty() {
-            return Some(NlDispatchResult::Unsat);
+fn realize_interfaces(
+    interfaces: &[Interface],
+    definitions: &[(TermId, TermId)],
+    arrays: &HashMap<TermId, ArrayInterp>,
+    manager: &TermManager,
+    env: &mut HashMap<TermId, BigInt>,
+) -> bool {
+    for iface in interfaces {
+        let Some(idx_val) = eval_int(iface.index, manager, arrays, env) else {
+            continue; // index not yet bound — skip for now
+        };
+        let Some(i64v) = idx_val.to_i64() else {
+            return false;
+        };
+        let Some(interp) = arrays.get(&iface.array) else {
+            return false;
+        };
+        let sel = interp
+            .entries
+            .get(&i64v)
+            .cloned()
+            .unwrap_or_else(|| interp.default.clone());
+        env.insert(iface.const_var, sel);
+    }
+    // Definitional eqs from nullary define-fun: `P = (* (select A i) …)`.
+    // Evaluate rhs once its free vars are bound; bind lhs.
+    for &(lhs, rhs) in definitions {
+        if env.contains_key(&lhs) {
+            continue;
         }
-        let mut pos = 0;
-        loop {
-            if pos >= domains.len() {
-                return Some(NlDispatchResult::Unsat);
-            }
-            idxs[pos] += 1;
-            if idxs[pos] <= domains[pos].2 {
-                break;
-            }
-            idxs[pos] = domains[pos].1;
-            pos += 1;
+        if !term_fully_bound(rhs, manager, env, arrays) {
+            continue;
+        }
+        let Some(v) = eval_int(rhs, manager, arrays, env) else {
+            return false;
+        };
+        env.insert(lhs, v);
+    }
+    true
+}
+
+fn partial_atoms_ok(
+    atoms: &[Atom],
+    bool_atoms: &[TermId],
+    arrays: &HashMap<TermId, ArrayInterp>,
+    manager: &TermManager,
+    env: &HashMap<TermId, BigInt>,
+) -> bool {
+    for atom in atoms {
+        // Only check atoms whose free vars are all bound.
+        if !term_fully_bound(atom.lhs, manager, env, arrays) {
+            continue;
+        }
+        if !term_fully_bound(atom.rhs, manager, env, arrays) {
+            continue;
+        }
+        if !eval_atom(atom, manager, arrays, env) {
+            return false;
         }
     }
+    for &b in bool_atoms {
+        if !term_fully_bound(b, manager, env, arrays) {
+            continue;
+        }
+        match eval_bool(b, manager, arrays, env) {
+            Some(true) => {}
+            _ => return false,
+        }
+    }
+    true
+}
+
+fn term_fully_bound(
+    term: TermId,
+    manager: &TermManager,
+    env: &HashMap<TermId, BigInt>,
+    arrays: &HashMap<TermId, ArrayInterp>,
+) -> bool {
+    let mut stack = vec![term];
+    let mut seen = HashSet::new();
+    while let Some(id) = stack.pop() {
+        if !seen.insert(id) {
+            continue;
+        }
+        if env.contains_key(&id) {
+            continue;
+        }
+        let Some(n) = manager.get(id) else {
+            return false;
+        };
+        match &n.kind {
+            TermKind::IntConst(_) | TermKind::True | TermKind::False => {}
+            TermKind::Var(_) => return false,
+            TermKind::Select(arr, idx) => {
+                if !arrays.contains_key(arr) {
+                    return false;
+                }
+                stack.push(*idx);
+            }
+            TermKind::Add(xs) | TermKind::Mul(xs) | TermKind::And(xs) | TermKind::Or(xs) => {
+                stack.extend(xs.iter().copied())
+            }
+            TermKind::Neg(a) | TermKind::Not(a) => stack.push(*a),
+            TermKind::Sub(a, b)
+            | TermKind::Div(a, b)
+            | TermKind::Mod(a, b)
+            | TermKind::Eq(a, b)
+            | TermKind::Le(a, b)
+            | TermKind::Lt(a, b)
+            | TermKind::Ge(a, b)
+            | TermKind::Gt(a, b) => {
+                stack.push(*a);
+                stack.push(*b);
+            }
+            TermKind::Ite(c, a, b) => {
+                stack.push(*c);
+                stack.push(*a);
+                stack.push(*b);
+            }
+            TermKind::Let { bindings, body } => {
+                for &(_, v) in bindings.iter() {
+                    stack.push(v);
+                }
+                stack.push(*body);
+            }
+            _ => return false,
+        }
+    }
+    true
+}
+
+/// `Some(true)` sat, `Some(false)` unsat (subtree exhausted), `None` budget.
+fn search_rec(
+    pos: usize,
+    domains: &[(TermId, i64, i64)],
+    interfaces: &[Interface],
+    definitions: &[(TermId, TermId)],
+    atoms: &[Atom],
+    bool_atoms: &[TermId],
+    arrays: &HashMap<TermId, ArrayInterp>,
+    manager: &TermManager,
+    env: &mut HashMap<TermId, BigInt>,
+    leaves: &mut u64,
+) -> Option<bool> {
+    if !realize_interfaces(interfaces, definitions, arrays, manager, env) {
+        return Some(false);
+    }
+    if !partial_atoms_ok(atoms, bool_atoms, arrays, manager, env) {
+        return Some(false);
+    }
+    if pos == domains.len() {
+        *leaves += 1;
+        if *leaves > MAX_LEAVES {
+            return None;
+        }
+        // Full assignment — atoms already checked when fully bound.
+        return Some(true);
+    }
+    let (var, lo, hi) = domains[pos];
+    for v in lo..=hi {
+        env.insert(var, BigInt::from(v));
+        match search_rec(
+            pos + 1,
+            domains,
+            interfaces,
+            definitions,
+            atoms,
+            bool_atoms,
+            arrays,
+            manager,
+            env,
+            leaves,
+        ) {
+            Some(true) => return Some(true),
+            Some(false) => {}
+            None => return None,
+        }
+        env.remove(&var);
+    }
+    Some(false)
 }
 
 #[derive(Clone, Debug)]
@@ -152,7 +311,7 @@ struct Interface {
 }
 
 #[derive(Clone, Debug)]
-struct ArithAtom {
+struct Atom {
     kind: CmpKind,
     lhs: TermId,
     rhs: TermId,
@@ -172,18 +331,37 @@ fn collect_assertion(
     manager: &TermManager,
     arrays: &mut HashMap<TermId, ArrayInterp>,
     interfaces: &mut Vec<Interface>,
+    definitions: &mut Vec<(TermId, TermId)>,
     bounds: &mut HashMap<TermId, (Option<i64>, Option<i64>)>,
-    atoms: &mut Vec<ArithAtom>,
+    atoms: &mut Vec<Atom>,
+    bool_atoms: &mut Vec<TermId>,
+    free_ints: &mut HashSet<TermId>,
 ) -> Option<()> {
     let t = manager.get(term)?;
     match &t.kind {
         TermKind::And(args) => {
             for &a in args {
-                collect_assertion(a, manager, arrays, interfaces, bounds, atoms)?;
+                collect_assertion(
+                    a,
+                    manager,
+                    arrays,
+                    interfaces,
+                    definitions,
+                    bounds,
+                    atoms,
+                    bool_atoms,
+                    free_ints,
+                )?;
             }
             Some(())
         }
         TermKind::True => Some(()),
+        TermKind::Not(_) | TermKind::Or(_) => {
+            // Boolean constraint that must hold (e.g. negated predicates).
+            collect_int_vars(term, manager, free_ints);
+            bool_atoms.push(term);
+            Some(())
+        }
         TermKind::Eq(lhs, rhs) => {
             if is_array_sorted(manager, *lhs) || is_array_sorted(manager, *rhs) {
                 let (var, def) = if is_array_var(manager, *lhs) {
@@ -193,39 +371,38 @@ fn collect_assertion(
                 } else {
                     return None;
                 };
-                let interp = eval_array_def(def, manager)?;
-                arrays.insert(var, interp);
+                arrays.insert(var, eval_array_def(def, manager)?);
                 return Some(());
             }
             if let Some(iface) = parse_interface(manager, *lhs, *rhs) {
                 interfaces.push(iface);
                 return Some(());
             }
+            // Definitional equality from nullary define-fun:
+            //   P = (* (select A i) (select B i))
+            // Bind P when the rhs is evaluable; do not search over P.
+            if let Some((v, body)) = parse_definition(manager, *lhs, *rhs) {
+                definitions.push((v, body));
+                collect_int_vars(body, manager, free_ints);
+                return Some(());
+            }
             if let Some((v, lo, hi)) = parse_bound_eq(manager, *lhs, *rhs) {
                 tighten(bounds, v, lo, hi);
-                return Some(());
+                free_ints.insert(v);
             }
-            // Pure arith equality (may mention purified consts / mul).
-            if is_pure_arith_term(*lhs, manager) && is_pure_arith_term(*rhs, manager) {
-                atoms.push(ArithAtom {
-                    kind: CmpKind::Eq,
-                    lhs: *lhs,
-                    rhs: *rhs,
-                });
-                return Some(());
-            }
-            None
+            collect_int_vars(*lhs, manager, free_ints);
+            collect_int_vars(*rhs, manager, free_ints);
+            atoms.push(Atom {
+                kind: CmpKind::Eq,
+                lhs: *lhs,
+                rhs: *rhs,
+            });
+            Some(())
         }
         TermKind::Le(a, b) | TermKind::Lt(a, b) | TermKind::Ge(a, b) | TermKind::Gt(a, b) => {
             if let Some((v, lo, hi)) = parse_bound_cmp(manager, term) {
                 tighten(bounds, v, lo, hi);
-                // Bounds on purified select-consts are also arith atoms.
-                if !as_var(manager, *a).is_some_and(|v| {
-                    // index var bounds only — already recorded
-                    interfaces.iter().all(|i| i.const_var != v)
-                }) {
-                    // if lhs is interface const, keep as atom
-                }
+                free_ints.insert(v);
             }
             let kind = match &t.kind {
                 TermKind::Le(_, _) => CmpKind::Le,
@@ -233,62 +410,262 @@ fn collect_assertion(
                 TermKind::Ge(_, _) => CmpKind::Ge,
                 _ => CmpKind::Gt,
             };
-            // Always keep numeric comparisons as atoms when both sides pure arith
-            // (includes bounds on select-consts like (>= c 1)).
-            if is_pure_arith_term(*a, manager) && is_pure_arith_term(*b, manager) {
-                // Skip pure index-var bounds already in `bounds` map (optional).
-                // Keeping them as atoms is fine and simpler.
-                atoms.push(ArithAtom {
-                    kind,
-                    lhs: *a,
-                    rhs: *b,
-                });
-                return Some(());
-            }
-            None
+            collect_int_vars(*a, manager, free_ints);
+            collect_int_vars(*b, manager, free_ints);
+            atoms.push(Atom {
+                kind,
+                lhs: *a,
+                rhs: *b,
+            });
+            Some(())
         }
         _ => None,
     }
 }
 
-fn tighten(
-    bounds: &mut HashMap<TermId, (Option<i64>, Option<i64>)>,
-    v: TermId,
-    lo: Option<i64>,
-    hi: Option<i64>,
-) {
-    let e = bounds.entry(v).or_insert((None, None));
-    if let Some(l) = lo {
-        e.0 = Some(e.0.map_or(l, |x| x.max(l)));
-    }
-    if let Some(h) = hi {
-        e.1 = Some(e.1.map_or(h, |x| x.min(h)));
-    }
-}
-
-fn is_pure_arith_term(term: TermId, manager: &TermManager) -> bool {
+fn collect_int_vars(term: TermId, manager: &TermManager, out: &mut HashSet<TermId>) {
     let mut stack = vec![term];
     let mut seen = HashSet::new();
     while let Some(id) = stack.pop() {
         if !seen.insert(id) {
             continue;
         }
-        let Some(n) = manager.get(id) else {
-            return false;
-        };
+        let Some(n) = manager.get(id) else { continue };
         match &n.kind {
-            TermKind::IntConst(_) | TermKind::Var(_) => {}
-            TermKind::Neg(a) => stack.push(*a),
-            TermKind::Add(xs) | TermKind::Mul(xs) => stack.extend(xs.iter().copied()),
-            TermKind::Sub(a, b) | TermKind::Div(a, b) | TermKind::Mod(a, b) => {
+            TermKind::Var(_) if n.sort == manager.sorts.int_sort => {
+                out.insert(id);
+            }
+            TermKind::Add(xs) | TermKind::Mul(xs) | TermKind::And(xs) | TermKind::Or(xs) => {
+                stack.extend(xs.iter().copied())
+            }
+            TermKind::Neg(a) | TermKind::Not(a) => stack.push(*a),
+            TermKind::Sub(a, b)
+            | TermKind::Div(a, b)
+            | TermKind::Mod(a, b)
+            | TermKind::Eq(a, b)
+            | TermKind::Le(a, b)
+            | TermKind::Lt(a, b)
+            | TermKind::Ge(a, b)
+            | TermKind::Gt(a, b)
+            | TermKind::Select(a, b) => {
                 stack.push(*a);
                 stack.push(*b);
             }
-            // No select/apply/store/ite in pure arith after purification.
-            _ => return false,
+            TermKind::Ite(c, a, b) | TermKind::Store(c, a, b) => {
+                stack.push(*c);
+                stack.push(*a);
+                stack.push(*b);
+            }
+            TermKind::Let { bindings, body } => {
+                for &(_, v) in bindings.iter() {
+                    stack.push(v);
+                }
+                stack.push(*body);
+            }
+            TermKind::Apply { args, .. } => stack.extend(args.iter().copied()),
+            _ => {}
         }
     }
-    true
+}
+
+fn ensure_selects_defined(
+    term: TermId,
+    manager: &TermManager,
+    arrays: &HashMap<TermId, ArrayInterp>,
+) -> Option<()> {
+    let mut stack = vec![term];
+    let mut seen = HashSet::new();
+    while let Some(id) = stack.pop() {
+        if !seen.insert(id) {
+            continue;
+        }
+        let n = manager.get(id)?;
+        match &n.kind {
+            TermKind::Select(arr, idx) => {
+                if !arrays.contains_key(arr) {
+                    return None;
+                }
+                stack.push(*idx);
+            }
+            TermKind::Add(xs) | TermKind::Mul(xs) => stack.extend(xs.iter().copied()),
+            TermKind::Neg(a) | TermKind::Not(a) => stack.push(*a),
+            TermKind::Sub(a, b)
+            | TermKind::Div(a, b)
+            | TermKind::Mod(a, b)
+            | TermKind::Eq(a, b)
+            | TermKind::Le(a, b)
+            | TermKind::Lt(a, b)
+            | TermKind::Ge(a, b)
+            | TermKind::Gt(a, b) => {
+                stack.push(*a);
+                stack.push(*b);
+            }
+            TermKind::Ite(c, a, b) => {
+                stack.push(*c);
+                stack.push(*a);
+                stack.push(*b);
+            }
+            TermKind::Let { bindings, body } => {
+                for &(_, v) in bindings.iter() {
+                    stack.push(v);
+                }
+                stack.push(*body);
+            }
+            TermKind::And(xs) | TermKind::Or(xs) => stack.extend(xs.iter().copied()),
+            TermKind::Var(_) | TermKind::IntConst(_) | TermKind::True | TermKind::False => {}
+            _ => return None,
+        }
+    }
+    Some(())
+}
+
+/// Evaluate integer or boolean term under env + arrays.
+fn eval_int(
+    term: TermId,
+    manager: &TermManager,
+    arrays: &HashMap<TermId, ArrayInterp>,
+    env: &HashMap<TermId, BigInt>,
+) -> Option<BigInt> {
+    if let Some(v) = env.get(&term) {
+        return Some(v.clone());
+    }
+    let n = manager.get(term)?;
+    match &n.kind {
+        TermKind::IntConst(k) => Some(k.clone()),
+        TermKind::Var(_) => None, // unbound
+        TermKind::Neg(a) => Some(-eval_int(*a, manager, arrays, env)?),
+        TermKind::Add(xs) => {
+            let mut s = BigInt::zero();
+            for &x in xs {
+                s += eval_int(x, manager, arrays, env)?;
+            }
+            Some(s)
+        }
+        TermKind::Mul(xs) => {
+            let mut p = BigInt::from(1);
+            for &x in xs {
+                p *= eval_int(x, manager, arrays, env)?;
+            }
+            Some(p)
+        }
+        TermKind::Sub(a, b) => {
+            Some(eval_int(*a, manager, arrays, env)? - eval_int(*b, manager, arrays, env)?)
+        }
+        TermKind::Select(arr, idx) => {
+            let i = eval_int(*idx, manager, arrays, env)?;
+            let i64v = i.to_i64()?;
+            let interp = arrays.get(arr)?;
+            Some(
+                interp
+                    .entries
+                    .get(&i64v)
+                    .cloned()
+                    .unwrap_or_else(|| interp.default.clone()),
+            )
+        }
+        TermKind::Ite(c, a, b) => {
+            if eval_bool(*c, manager, arrays, env)? {
+                eval_int(*a, manager, arrays, env)
+            } else {
+                eval_int(*b, manager, arrays, env)
+            }
+        }
+        TermKind::Let { bindings, body } => {
+            // Parser inlines let-names into the body via the binding table while
+            // parsing, so `body` already contains the bound values as subterms.
+            // Still evaluate binding values first (in case substitute left name
+            // vars), then body. Bindings are `(name_spur, value_term)`.
+            let local = env.clone();
+            for &(_name, val_term) in bindings {
+                // Force evaluation of binding values (side-effect free).
+                let _ = eval_int(val_term, manager, arrays, &local)?;
+            }
+            eval_int(*body, manager, arrays, &local)
+        }
+        _ => None,
+    }
+}
+
+fn eval_bool(
+    term: TermId,
+    manager: &TermManager,
+    arrays: &HashMap<TermId, ArrayInterp>,
+    env: &HashMap<TermId, BigInt>,
+) -> Option<bool> {
+    let n = manager.get(term)?;
+    match &n.kind {
+        TermKind::True => Some(true),
+        TermKind::False => Some(false),
+        TermKind::Not(a) => Some(!eval_bool(*a, manager, arrays, env)?),
+        TermKind::And(xs) => {
+            for &x in xs {
+                if !eval_bool(x, manager, arrays, env)? {
+                    return Some(false);
+                }
+            }
+            Some(true)
+        }
+        TermKind::Or(xs) => {
+            for &x in xs {
+                if eval_bool(x, manager, arrays, env)? {
+                    return Some(true);
+                }
+            }
+            Some(false)
+        }
+        TermKind::Eq(a, b) => {
+            // Could be int or bool eq
+            if manager.get(*a).is_some_and(|t| t.sort == manager.sorts.bool_sort) {
+                Some(
+                    eval_bool(*a, manager, arrays, env)?
+                        == eval_bool(*b, manager, arrays, env)?,
+                )
+            } else {
+                Some(eval_int(*a, manager, arrays, env)? == eval_int(*b, manager, arrays, env)?)
+            }
+        }
+        TermKind::Le(a, b) => {
+            Some(eval_int(*a, manager, arrays, env)? <= eval_int(*b, manager, arrays, env)?)
+        }
+        TermKind::Lt(a, b) => {
+            Some(eval_int(*a, manager, arrays, env)? < eval_int(*b, manager, arrays, env)?)
+        }
+        TermKind::Ge(a, b) => {
+            Some(eval_int(*a, manager, arrays, env)? >= eval_int(*b, manager, arrays, env)?)
+        }
+        TermKind::Gt(a, b) => {
+            Some(eval_int(*a, manager, arrays, env)? > eval_int(*b, manager, arrays, env)?)
+        }
+        TermKind::Ite(c, a, b) => {
+            if eval_bool(*c, manager, arrays, env)? {
+                eval_bool(*a, manager, arrays, env)
+            } else {
+                eval_bool(*b, manager, arrays, env)
+            }
+        }
+        _ => None,
+    }
+}
+
+fn eval_atom(
+    atom: &Atom,
+    manager: &TermManager,
+    arrays: &HashMap<TermId, ArrayInterp>,
+    env: &HashMap<TermId, BigInt>,
+) -> bool {
+    let Some(l) = eval_int(atom.lhs, manager, arrays, env) else {
+        return false;
+    };
+    let Some(r) = eval_int(atom.rhs, manager, arrays, env) else {
+        return false;
+    };
+    match atom.kind {
+        CmpKind::Eq => l == r,
+        CmpKind::Le => l <= r,
+        CmpKind::Lt => l < r,
+        CmpKind::Ge => l >= r,
+        CmpKind::Gt => l > r,
+    }
 }
 
 fn parse_interface(manager: &TermManager, a: TermId, b: TermId) -> Option<Interface> {
@@ -308,6 +685,76 @@ fn parse_interface(manager: &TermManager, a: TermId, b: TermId) -> Option<Interf
         })
     };
     one(a, b).or_else(|| one(b, a))
+}
+
+/// `v = t` where `v` is a variable and `t` is a non-variable evaluable term
+/// (nullary define-fun body: product of selects, ite, …).
+fn parse_definition(
+    manager: &TermManager,
+    a: TermId,
+    b: TermId,
+) -> Option<(TermId, TermId)> {
+    let one = |v, body| {
+        if as_var(manager, v).is_none() {
+            return None;
+        }
+        // Body must not itself be a bare variable or numeral-only (those are
+        // ordinary eqs / bounds).
+        if as_var(manager, body).is_some() || eval_ground_int(body, manager).is_some() {
+            return None;
+        }
+        // Must be evaluable under a concrete index env (select/ite/mul/…).
+        if !is_evaluable_arith(body, manager) {
+            return None;
+        }
+        Some((v, body))
+    };
+    one(a, b).or_else(|| one(b, a))
+}
+
+fn is_evaluable_arith(term: TermId, manager: &TermManager) -> bool {
+    let mut stack = vec![term];
+    let mut seen = HashSet::new();
+    while let Some(id) = stack.pop() {
+        if !seen.insert(id) {
+            continue;
+        }
+        let Some(n) = manager.get(id) else {
+            return false;
+        };
+        match &n.kind {
+            TermKind::IntConst(_) | TermKind::Var(_) => {}
+            TermKind::Neg(a) | TermKind::Not(a) => stack.push(*a),
+            TermKind::Add(xs) | TermKind::Mul(xs) | TermKind::And(xs) | TermKind::Or(xs) => {
+                stack.extend(xs.iter().copied())
+            }
+            TermKind::Sub(a, b)
+            | TermKind::Div(a, b)
+            | TermKind::Mod(a, b)
+            | TermKind::Eq(a, b)
+            | TermKind::Le(a, b)
+            | TermKind::Lt(a, b)
+            | TermKind::Ge(a, b)
+            | TermKind::Gt(a, b)
+            | TermKind::Select(a, b) => {
+                stack.push(*a);
+                stack.push(*b);
+            }
+            TermKind::Ite(c, a, b) => {
+                stack.push(*c);
+                stack.push(*a);
+                stack.push(*b);
+            }
+            TermKind::Let { bindings, body } => {
+                for &(_, v) in bindings.iter() {
+                    stack.push(v);
+                }
+                stack.push(*body);
+            }
+            _ => return false,
+        }
+    }
+    true
 }
 
 fn is_array_sorted(manager: &TermManager, t: TermId) -> bool {
@@ -417,64 +864,18 @@ fn as_var(manager: &TermManager, t: TermId) -> Option<TermId> {
         .and_then(|n| matches!(n.kind, TermKind::Var(_)).then_some(t))
 }
 
-fn eval_term(
-    term: TermId,
-    manager: &TermManager,
-    env: &HashMap<TermId, BigInt>,
-    cache: &mut HashMap<TermId, BigInt>,
-) -> Option<BigInt> {
-    if let Some(v) = cache.get(&term) {
-        return Some(v.clone());
+fn tighten(
+    bounds: &mut HashMap<TermId, (Option<i64>, Option<i64>)>,
+    v: TermId,
+    lo: Option<i64>,
+    hi: Option<i64>,
+) {
+    let e = bounds.entry(v).or_insert((None, None));
+    if let Some(l) = lo {
+        e.0 = Some(e.0.map_or(l, |x| x.max(l)));
     }
-    if let Some(v) = env.get(&term) {
-        return Some(v.clone());
-    }
-    let n = manager.get(term)?;
-    let val = match &n.kind {
-        TermKind::IntConst(k) => k.clone(),
-        TermKind::Neg(a) => -eval_term(*a, manager, env, cache)?,
-        TermKind::Add(xs) => {
-            let mut s = BigInt::zero();
-            for &x in xs {
-                s += eval_term(x, manager, env, cache)?;
-            }
-            s
-        }
-        TermKind::Mul(xs) => {
-            let mut p = BigInt::from(1);
-            for &x in xs {
-                p *= eval_term(x, manager, env, cache)?;
-            }
-            p
-        }
-        TermKind::Sub(a, b) => {
-            eval_term(*a, manager, env, cache)? - eval_term(*b, manager, env, cache)?
-        }
-        TermKind::Var(_) => return None,
-        _ => return None,
-    };
-    cache.insert(term, val.clone());
-    Some(val)
-}
-
-fn eval_atom(
-    atom: &ArithAtom,
-    manager: &TermManager,
-    env: &HashMap<TermId, BigInt>,
-    cache: &mut HashMap<TermId, BigInt>,
-) -> bool {
-    let Some(l) = eval_term(atom.lhs, manager, env, cache) else {
-        return false;
-    };
-    let Some(r) = eval_term(atom.rhs, manager, env, cache) else {
-        return false;
-    };
-    match atom.kind {
-        CmpKind::Eq => l == r,
-        CmpKind::Le => l <= r,
-        CmpKind::Lt => l < r,
-        CmpKind::Ge => l >= r,
-        CmpKind::Gt => l > r,
+    if let Some(h) = hi {
+        e.1 = Some(e.1.map_or(h, |x| x.min(h)));
     }
 }
 

--- a/oxiz-theories/src/ania_ground.rs
+++ b/oxiz-theories/src/ania_ground.rs
@@ -11,6 +11,7 @@
 
 use crate::nlsat::NlDispatchResult;
 use num_bigint::BigInt;
+use num_rational::BigRational;
 use num_traits::{ToPrimitive, Zero};
 use oxiz_core::ast::{TermId, TermKind, TermManager};
 use oxiz_core::sort::SortKind;
@@ -109,7 +110,13 @@ pub fn try_decide_ground_ania(
         &mut env,
         &mut leaves,
     ) {
-        Some(true) => Some(NlDispatchResult::Sat),
+        Some(true) => {
+            let mut assignments = HashMap::new();
+            for (term, val) in env {
+                assignments.insert(term, BigRational::from_integer(val));
+            }
+            Some(NlDispatchResult::sat_with(assignments))
+        }
         Some(false) => Some(NlDispatchResult::Unsat),
         None => None, // exhausted leaf budget
     }

--- a/oxiz-theories/src/ania_ground.rs
+++ b/oxiz-theories/src/ania_ground.rs
@@ -1,0 +1,520 @@
+//! Ground QF_ANIA decision for constant store-chains + finite index boxes.
+//!
+//! Works on **purified** assertions:
+//! - `A = store(... (as const) d ...)` array definitions
+//! - `c = select(A, i)` interface equalities from arithmetic purification
+//! - pure arithmetic on `c` and index vars
+//!
+//! Free selects (no store def) are out of scope here — pure NIA on interface
+//! constants remains sound for those.
+
+use crate::nlsat::NlDispatchResult;
+use num_bigint::BigInt;
+use num_traits::{ToPrimitive, Zero};
+use oxiz_core::ast::{TermId, TermKind, TermManager};
+use oxiz_core::sort::SortKind;
+use std::collections::{HashMap, HashSet};
+
+const MAX_INDEX_PRODUCT: u64 = 50_000;
+
+/// Try to decide ground store + bounded-index ANIA (post-purification shape).
+pub fn try_decide_ground_ania(
+    assertions: &[TermId],
+    manager: &TermManager,
+) -> Option<NlDispatchResult> {
+    let mut arrays: HashMap<TermId, ArrayInterp> = HashMap::new();
+    let mut interfaces: Vec<Interface> = Vec::new(); // c = select(A, idx)
+    let mut bounds: HashMap<TermId, (Option<i64>, Option<i64>)> = HashMap::new();
+    let mut arith_atoms: Vec<ArithAtom> = Vec::new();
+
+    for &a in assertions {
+        collect_assertion(
+            a,
+            manager,
+            &mut arrays,
+            &mut interfaces,
+            &mut bounds,
+            &mut arith_atoms,
+        )?;
+    }
+
+    if arrays.is_empty() || interfaces.is_empty() || arith_atoms.is_empty() {
+        return None;
+    }
+
+    // Every interface select must read a defined array; index must be var or numeral.
+    let mut index_vars: Vec<TermId> = Vec::new();
+    for iface in &interfaces {
+        if !arrays.contains_key(&iface.array) {
+            return None;
+        }
+        if let Some(v) = as_var(manager, iface.index) {
+            if !index_vars.contains(&v) {
+                index_vars.push(v);
+            }
+        } else if eval_ground_int(iface.index, manager).is_none() {
+            return None;
+        }
+    }
+
+    let mut domains: Vec<(TermId, i64, i64)> = Vec::new();
+    let mut product: u64 = 1;
+    for &v in &index_vars {
+        let (lo, hi) = bounds.get(&v).copied().unwrap_or((None, None));
+        let lo = lo?;
+        let hi = hi?;
+        if hi < lo {
+            return Some(NlDispatchResult::Unsat);
+        }
+        let w = (hi - lo + 1) as u64;
+        product = product.saturating_mul(w);
+        if product > MAX_INDEX_PRODUCT {
+            return None;
+        }
+        domains.push((v, lo, hi));
+    }
+
+    let mut idxs: Vec<i64> = domains.iter().map(|(_, lo, _)| *lo).collect();
+    loop {
+        let mut env: HashMap<TermId, BigInt> = HashMap::new();
+        for (i, &(v, _, _)) in domains.iter().enumerate() {
+            env.insert(v, BigInt::from(idxs[i]));
+        }
+        // Realize each interface const via store evaluation.
+        let mut ok = true;
+        for iface in &interfaces {
+            let idx_val = if let Some(v) = as_var(manager, iface.index) {
+                env.get(&v).cloned().ok_or(())
+            } else {
+                eval_ground_int(iface.index, manager)
+                    .map(BigInt::from)
+                    .ok_or(())
+            };
+            let Ok(idx_val) = idx_val else {
+                ok = false;
+                break;
+            };
+            let Some(i64v) = idx_val.to_i64() else {
+                ok = false;
+                break;
+            };
+            let interp = &arrays[&iface.array];
+            let sel = interp
+                .entries
+                .get(&i64v)
+                .cloned()
+                .unwrap_or_else(|| interp.default.clone());
+            env.insert(iface.const_var, sel);
+        }
+        if ok {
+            let mut cache = HashMap::new();
+            let mut all_hold = true;
+            for atom in &arith_atoms {
+                if !eval_atom(atom, manager, &env, &mut cache) {
+                    all_hold = false;
+                    break;
+                }
+            }
+            if all_hold {
+                return Some(NlDispatchResult::Sat);
+            }
+        }
+
+        if domains.is_empty() {
+            return Some(NlDispatchResult::Unsat);
+        }
+        let mut pos = 0;
+        loop {
+            if pos >= domains.len() {
+                return Some(NlDispatchResult::Unsat);
+            }
+            idxs[pos] += 1;
+            if idxs[pos] <= domains[pos].2 {
+                break;
+            }
+            idxs[pos] = domains[pos].1;
+            pos += 1;
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ArrayInterp {
+    default: BigInt,
+    entries: HashMap<i64, BigInt>,
+}
+
+#[derive(Clone, Debug)]
+struct Interface {
+    const_var: TermId,
+    array: TermId,
+    index: TermId,
+}
+
+#[derive(Clone, Debug)]
+struct ArithAtom {
+    kind: CmpKind,
+    lhs: TermId,
+    rhs: TermId,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum CmpKind {
+    Eq,
+    Le,
+    Lt,
+    Ge,
+    Gt,
+}
+
+fn collect_assertion(
+    term: TermId,
+    manager: &TermManager,
+    arrays: &mut HashMap<TermId, ArrayInterp>,
+    interfaces: &mut Vec<Interface>,
+    bounds: &mut HashMap<TermId, (Option<i64>, Option<i64>)>,
+    atoms: &mut Vec<ArithAtom>,
+) -> Option<()> {
+    let t = manager.get(term)?;
+    match &t.kind {
+        TermKind::And(args) => {
+            for &a in args {
+                collect_assertion(a, manager, arrays, interfaces, bounds, atoms)?;
+            }
+            Some(())
+        }
+        TermKind::True => Some(()),
+        TermKind::Eq(lhs, rhs) => {
+            if is_array_sorted(manager, *lhs) || is_array_sorted(manager, *rhs) {
+                let (var, def) = if is_array_var(manager, *lhs) {
+                    (*lhs, *rhs)
+                } else if is_array_var(manager, *rhs) {
+                    (*rhs, *lhs)
+                } else {
+                    return None;
+                };
+                let interp = eval_array_def(def, manager)?;
+                arrays.insert(var, interp);
+                return Some(());
+            }
+            if let Some(iface) = parse_interface(manager, *lhs, *rhs) {
+                interfaces.push(iface);
+                return Some(());
+            }
+            if let Some((v, lo, hi)) = parse_bound_eq(manager, *lhs, *rhs) {
+                tighten(bounds, v, lo, hi);
+                return Some(());
+            }
+            // Pure arith equality (may mention purified consts / mul).
+            if is_pure_arith_term(*lhs, manager) && is_pure_arith_term(*rhs, manager) {
+                atoms.push(ArithAtom {
+                    kind: CmpKind::Eq,
+                    lhs: *lhs,
+                    rhs: *rhs,
+                });
+                return Some(());
+            }
+            None
+        }
+        TermKind::Le(a, b) | TermKind::Lt(a, b) | TermKind::Ge(a, b) | TermKind::Gt(a, b) => {
+            if let Some((v, lo, hi)) = parse_bound_cmp(manager, term) {
+                tighten(bounds, v, lo, hi);
+                // Bounds on purified select-consts are also arith atoms.
+                if !as_var(manager, *a).is_some_and(|v| {
+                    // index var bounds only — already recorded
+                    interfaces.iter().all(|i| i.const_var != v)
+                }) {
+                    // if lhs is interface const, keep as atom
+                }
+            }
+            let kind = match &t.kind {
+                TermKind::Le(_, _) => CmpKind::Le,
+                TermKind::Lt(_, _) => CmpKind::Lt,
+                TermKind::Ge(_, _) => CmpKind::Ge,
+                _ => CmpKind::Gt,
+            };
+            // Always keep numeric comparisons as atoms when both sides pure arith
+            // (includes bounds on select-consts like (>= c 1)).
+            if is_pure_arith_term(*a, manager) && is_pure_arith_term(*b, manager) {
+                // Skip pure index-var bounds already in `bounds` map (optional).
+                // Keeping them as atoms is fine and simpler.
+                atoms.push(ArithAtom {
+                    kind,
+                    lhs: *a,
+                    rhs: *b,
+                });
+                return Some(());
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+fn tighten(
+    bounds: &mut HashMap<TermId, (Option<i64>, Option<i64>)>,
+    v: TermId,
+    lo: Option<i64>,
+    hi: Option<i64>,
+) {
+    let e = bounds.entry(v).or_insert((None, None));
+    if let Some(l) = lo {
+        e.0 = Some(e.0.map_or(l, |x| x.max(l)));
+    }
+    if let Some(h) = hi {
+        e.1 = Some(e.1.map_or(h, |x| x.min(h)));
+    }
+}
+
+fn is_pure_arith_term(term: TermId, manager: &TermManager) -> bool {
+    let mut stack = vec![term];
+    let mut seen = HashSet::new();
+    while let Some(id) = stack.pop() {
+        if !seen.insert(id) {
+            continue;
+        }
+        let Some(n) = manager.get(id) else {
+            return false;
+        };
+        match &n.kind {
+            TermKind::IntConst(_) | TermKind::Var(_) => {}
+            TermKind::Neg(a) => stack.push(*a),
+            TermKind::Add(xs) | TermKind::Mul(xs) => stack.extend(xs.iter().copied()),
+            TermKind::Sub(a, b) | TermKind::Div(a, b) | TermKind::Mod(a, b) => {
+                stack.push(*a);
+                stack.push(*b);
+            }
+            // No select/apply/store/ite in pure arith after purification.
+            _ => return false,
+        }
+    }
+    true
+}
+
+fn parse_interface(manager: &TermManager, a: TermId, b: TermId) -> Option<Interface> {
+    let one = |c, s| {
+        let cn = manager.get(c)?;
+        let sn = manager.get(s)?;
+        if !matches!(cn.kind, TermKind::Var(_)) {
+            return None;
+        }
+        let TermKind::Select(arr, idx) = &sn.kind else {
+            return None;
+        };
+        Some(Interface {
+            const_var: c,
+            array: *arr,
+            index: *idx,
+        })
+    };
+    one(a, b).or_else(|| one(b, a))
+}
+
+fn is_array_sorted(manager: &TermManager, t: TermId) -> bool {
+    manager.get(t).is_some_and(|n| {
+        manager
+            .sorts
+            .get(n.sort)
+            .is_some_and(|s| matches!(s.kind, SortKind::Array { .. }))
+    })
+}
+
+fn is_array_var(manager: &TermManager, t: TermId) -> bool {
+    manager
+        .get(t)
+        .is_some_and(|n| matches!(n.kind, TermKind::Var(_)) && is_array_sorted(manager, t))
+}
+
+fn eval_array_def(term: TermId, manager: &TermManager) -> Option<ArrayInterp> {
+    let mut cur = term;
+    let mut entries_rev: Vec<(i64, BigInt)> = Vec::new();
+    loop {
+        let n = manager.get(cur)?;
+        match &n.kind {
+            TermKind::Store(arr, idx, val) => {
+                let i = eval_ground_int(*idx, manager)?;
+                let v = eval_ground_int(*val, manager)?;
+                entries_rev.push((i, BigInt::from(v)));
+                cur = *arr;
+            }
+            TermKind::Apply { func, args } => {
+                let name = manager.resolve_str(*func);
+                if name.contains("const") && args.len() == 1 {
+                    let d = eval_ground_int(args[0], manager)?;
+                    let mut entries = HashMap::new();
+                    for (i, v) in entries_rev.into_iter().rev() {
+                        entries.insert(i, v);
+                    }
+                    return Some(ArrayInterp {
+                        default: BigInt::from(d),
+                        entries,
+                    });
+                }
+                return None;
+            }
+            _ => return None,
+        }
+    }
+}
+
+fn eval_ground_int(term: TermId, manager: &TermManager) -> Option<i64> {
+    let n = manager.get(term)?;
+    match &n.kind {
+        TermKind::IntConst(k) => k.to_i64(),
+        TermKind::Neg(inner) => Some(-eval_ground_int(*inner, manager)?),
+        _ => None,
+    }
+}
+
+fn parse_bound_eq(
+    manager: &TermManager,
+    lhs: TermId,
+    rhs: TermId,
+) -> Option<(TermId, Option<i64>, Option<i64>)> {
+    if let (Some(v), Some(k)) = (as_var(manager, lhs), eval_ground_int(rhs, manager)) {
+        return Some((v, Some(k), Some(k)));
+    }
+    if let (Some(v), Some(k)) = (as_var(manager, rhs), eval_ground_int(lhs, manager)) {
+        return Some((v, Some(k), Some(k)));
+    }
+    None
+}
+
+fn parse_bound_cmp(
+    manager: &TermManager,
+    term: TermId,
+) -> Option<(TermId, Option<i64>, Option<i64>)> {
+    let n = manager.get(term)?;
+    match &n.kind {
+        TermKind::Ge(a, b) => {
+            if let (Some(v), Some(k)) = (as_var(manager, *a), eval_ground_int(*b, manager)) {
+                return Some((v, Some(k), None));
+            }
+        }
+        TermKind::Gt(a, b) => {
+            if let (Some(v), Some(k)) = (as_var(manager, *a), eval_ground_int(*b, manager)) {
+                return Some((v, Some(k + 1), None));
+            }
+        }
+        TermKind::Le(a, b) => {
+            if let (Some(v), Some(k)) = (as_var(manager, *a), eval_ground_int(*b, manager)) {
+                return Some((v, None, Some(k)));
+            }
+        }
+        TermKind::Lt(a, b) => {
+            if let (Some(v), Some(k)) = (as_var(manager, *a), eval_ground_int(*b, manager)) {
+                return Some((v, None, Some(k - 1)));
+            }
+        }
+        _ => {}
+    }
+    None
+}
+
+fn as_var(manager: &TermManager, t: TermId) -> Option<TermId> {
+    manager
+        .get(t)
+        .and_then(|n| matches!(n.kind, TermKind::Var(_)).then_some(t))
+}
+
+fn eval_term(
+    term: TermId,
+    manager: &TermManager,
+    env: &HashMap<TermId, BigInt>,
+    cache: &mut HashMap<TermId, BigInt>,
+) -> Option<BigInt> {
+    if let Some(v) = cache.get(&term) {
+        return Some(v.clone());
+    }
+    if let Some(v) = env.get(&term) {
+        return Some(v.clone());
+    }
+    let n = manager.get(term)?;
+    let val = match &n.kind {
+        TermKind::IntConst(k) => k.clone(),
+        TermKind::Neg(a) => -eval_term(*a, manager, env, cache)?,
+        TermKind::Add(xs) => {
+            let mut s = BigInt::zero();
+            for &x in xs {
+                s += eval_term(x, manager, env, cache)?;
+            }
+            s
+        }
+        TermKind::Mul(xs) => {
+            let mut p = BigInt::from(1);
+            for &x in xs {
+                p *= eval_term(x, manager, env, cache)?;
+            }
+            p
+        }
+        TermKind::Sub(a, b) => {
+            eval_term(*a, manager, env, cache)? - eval_term(*b, manager, env, cache)?
+        }
+        TermKind::Var(_) => return None,
+        _ => return None,
+    };
+    cache.insert(term, val.clone());
+    Some(val)
+}
+
+fn eval_atom(
+    atom: &ArithAtom,
+    manager: &TermManager,
+    env: &HashMap<TermId, BigInt>,
+    cache: &mut HashMap<TermId, BigInt>,
+) -> bool {
+    let Some(l) = eval_term(atom.lhs, manager, env, cache) else {
+        return false;
+    };
+    let Some(r) = eval_term(atom.rhs, manager, env, cache) else {
+        return false;
+    };
+    match atom.kind {
+        CmpKind::Eq => l == r,
+        CmpKind::Le => l <= r,
+        CmpKind::Lt => l < r,
+        CmpKind::Ge => l >= r,
+        CmpKind::Gt => l > r,
+    }
+}
+
+/// True if any assertion contains a `store`.
+pub fn assertions_contain_store(assertions: &[TermId], manager: &TermManager) -> bool {
+    assertions.iter().any(|&a| term_contains_store(a, manager))
+}
+
+fn term_contains_store(term: TermId, manager: &TermManager) -> bool {
+    let mut stack = vec![term];
+    let mut seen = HashSet::new();
+    while let Some(id) = stack.pop() {
+        if !seen.insert(id) {
+            continue;
+        }
+        let Some(n) = manager.get(id) else { continue };
+        match &n.kind {
+            TermKind::Store(_, _, _) => return true,
+            TermKind::And(xs) | TermKind::Or(xs) | TermKind::Add(xs) | TermKind::Mul(xs) => {
+                stack.extend(xs.iter().copied())
+            }
+            TermKind::Eq(a, b)
+            | TermKind::Le(a, b)
+            | TermKind::Lt(a, b)
+            | TermKind::Ge(a, b)
+            | TermKind::Gt(a, b)
+            | TermKind::Sub(a, b)
+            | TermKind::Select(a, b) => {
+                stack.push(*a);
+                stack.push(*b);
+            }
+            TermKind::Neg(a) | TermKind::Not(a) => stack.push(*a),
+            TermKind::Ite(c, a, b) => {
+                stack.push(*c);
+                stack.push(*a);
+                stack.push(*b);
+            }
+            TermKind::Apply { args, .. } => stack.extend(args.iter().copied()),
+            _ => {}
+        }
+    }
+    false
+}

--- a/oxiz-theories/src/lib.rs
+++ b/oxiz-theories/src/lib.rs
@@ -100,6 +100,7 @@ pub mod wmaxsat;
 #[cfg(feature = "std")]
 pub mod checking;
 #[cfg(feature = "std")]
+pub mod ania_ground;
 pub mod nlsat;
 #[cfg(feature = "std")]
 pub mod sls;

--- a/oxiz-theories/src/nlsat.rs
+++ b/oxiz-theories/src/nlsat.rs
@@ -143,6 +143,19 @@ impl<'a> TermPolyTranslator<'a> {
                     _ => Some(Polynomial::from_var(r)),
                 }
             }
+            // After assert-time purification, foreign numeric leaves are
+            // already fresh Vars. Keep a defensive opaque mapping only for
+            // residual Select/Apply that somehow bypassed purification.
+            TermKind::Select(_, _) | TermKind::Apply { .. } => {
+                let term = self.manager.get(term_id)?;
+                if term.sort != self.manager.sorts.int_sort
+                    && term.sort != self.manager.sorts.real_sort
+                {
+                    return None;
+                }
+                let v = self.get_or_create_var(term_id);
+                Some(Polynomial::from_var(v))
+            }
             _ => None,
         }
     }
@@ -322,6 +335,10 @@ fn term_contains_divmod(term_id: TermId, manager: &TermManager) -> bool {
     }
 }
 
+fn is_numeric_sort(manager: &TermManager, sort: oxiz_core::sort::SortId) -> bool {
+    sort == manager.sorts.int_sort || sort == manager.sorts.real_sort
+}
+
 fn contains_non_polynomial_ops(term_id: TermId, manager: &TermManager) -> bool {
     let Some(term) = manager.get(term_id) else {
         return false;
@@ -333,8 +350,30 @@ fn contains_non_polynomial_ops(term_id: TermId, manager: &TermManager) -> bool {
         TermKind::Div(lhs, rhs) | TermKind::Mod(lhs, rhs) => {
             contains_non_polynomial_ops(*lhs, manager) || contains_non_polynomial_ops(*rhs, manager)
         }
-        TermKind::Apply { .. }
-        | TermKind::Forall { .. }
+        // Numeric `select` / uninterpreted apply are opaque poly variables.
+        // Non-numeric applies and array `store` are out of the pure poly layer.
+        TermKind::Select(arr, idx) => {
+            if !is_numeric_sort(manager, term.sort) {
+                return true;
+            }
+            contains_non_polynomial_ops(*arr, manager) || contains_non_polynomial_ops(*idx, manager)
+        }
+        TermKind::Apply { args, .. } => {
+            if !is_numeric_sort(manager, term.sort) {
+                return true;
+            }
+            args.iter()
+                .any(|&a| contains_non_polynomial_ops(a, manager))
+        }
+        // `store` only matters for array theory; it is not an arith op. When
+        // it appears solely inside array-sorted equalities the NIA dispatcher
+        // skips those assertions entirely.
+        TermKind::Store(a, i, v) => {
+            contains_non_polynomial_ops(*a, manager)
+                || contains_non_polynomial_ops(*i, manager)
+                || contains_non_polynomial_ops(*v, manager)
+        }
+        TermKind::Forall { .. }
         | TermKind::Exists { .. }
         | TermKind::Let { .. }
         | TermKind::Match { .. } => true,
@@ -382,16 +421,71 @@ struct PolyAtom {
 // Assertion-level translation (integer mode)
 // ─────────────────────────────────────────────────────────────────────────────
 
+fn is_array_sort_id(manager: &TermManager, sort: oxiz_core::sort::SortId) -> bool {
+    manager
+        .sorts
+        .get(sort)
+        .is_some_and(|s| matches!(s.kind, oxiz_core::sort::SortKind::Array { .. }))
+}
+
+/// Array-equality assertions (e.g. `A = store(...)`) belong to the array
+/// theory, not the polynomial layer. Skipping them is not a relaxation of the
+/// arithmetic fragment.
+fn is_array_structural_eq(manager: &TermManager, lhs: TermId, rhs: TermId) -> bool {
+    let ls = manager.get(lhs).map(|t| t.sort);
+    let rs = manager.get(rhs).map(|t| t.sort);
+    ls.is_some_and(|s| is_array_sort_id(manager, s))
+        || rs.is_some_and(|s| is_array_sort_id(manager, s))
+}
+
+/// Assertion contributes nothing to the pure arithmetic fragment.
+fn assertion_is_array_only(term_id: TermId, manager: &TermManager) -> bool {
+    let Some(term) = manager.get(term_id) else {
+        return false;
+    };
+    match &term.kind {
+        TermKind::Eq(a, b) => {
+            is_array_structural_eq(manager, *a, *b) || is_arith_interface_eq(manager, *a, *b)
+        }
+        TermKind::And(args) => args.iter().all(|&a| assertion_is_array_only(a, manager)),
+        TermKind::True => true,
+        _ => false,
+    }
+}
+
+fn is_arith_interface_eq(manager: &TermManager, lhs: TermId, rhs: TermId) -> bool {
+    fn is_var(manager: &TermManager, t: TermId) -> bool {
+        manager
+            .get(t)
+            .is_some_and(|n| matches!(n.kind, TermKind::Var(_)))
+    }
+    fn is_foreign_numeric(manager: &TermManager, t: TermId) -> bool {
+        let Some(n) = manager.get(t) else {
+            return false;
+        };
+        if n.sort != manager.sorts.int_sort && n.sort != manager.sorts.real_sort {
+            return false;
+        }
+        matches!(
+            n.kind,
+            TermKind::Select(_, _)
+                | TermKind::Apply { .. }
+                | TermKind::Store(_, _, _)
+                | TermKind::Ite(_, _, _)
+        )
+    }
+    (is_var(manager, lhs) && is_foreign_numeric(manager, rhs))
+        || (is_var(manager, rhs) && is_foreign_numeric(manager, lhs))
+}
+
 /// Extract polynomial atoms from a top-level assertion.
 ///
 /// `incomplete` is set to `true` whenever some part of the assertion could
 /// **not** be captured as a pure conjunction of polynomial atoms — an
 /// unrecognized top-level connective (`Or`/`Not`/`Distinct`/`Ite`/…) or a
-/// comparison whose operand does not translate to a polynomial (e.g. it
-/// contains `Div`/`Mod`/an uninterpreted apply). The dispatcher must treat a
-/// `Sat` verdict as untrustworthy once `incomplete` is set, because the solver
-/// then only sees a strictly weaker (relaxed) subproblem. Reference: Z3's
-/// nlsat/nlsat_solver.cpp only trusts a model for the full atom set.
+/// comparison whose operand does not translate to a polynomial. Array
+/// structural equalities are skipped (not incomplete): after assert-time
+/// purification they are separate from the pure arith fragment.
 fn extract_poly_atoms(
     term_id: TermId,
     manager: &TermManager,
@@ -405,6 +499,15 @@ fn extract_poly_atoms(
     };
     match &term.kind.clone() {
         TermKind::Eq(lhs, rhs) => {
+            if is_array_structural_eq(manager, *lhs, *rhs) {
+                return;
+            }
+            // Interface naming from purification: `c = select(...)` / `c = f(...)`.
+            // The pure arith fragment already uses `c`; encoding the foreign side
+            // as a second poly var would leave it unbounded and break B&B/enum.
+            if is_arith_interface_eq(manager, *lhs, *rhs) {
+                return;
+            }
             if let (Some(lp), Some(rp)) = (translator.translate(*lhs), translator.translate(*rhs)) {
                 out.push(PolyAtom {
                     poly: Polynomial::sub(&lp, &rp),
@@ -468,6 +571,18 @@ fn extract_poly_atoms(
                 extract_poly_atoms(arg, manager, translator, out, incomplete);
             }
         }
+        // Interface equalities that collapsed to reflexivity after purification
+        // (`c = c`) are no-ops for the arithmetic fragment.
+        TermKind::True => {}
+        TermKind::False => {
+            // Explicit false in the conjunction → arith fragment is unsat.
+            // Encode as 0 = 1.
+            out.push(PolyAtom {
+                poly: Polynomial::constant(BigRational::from_integer(1.into())),
+                kind: AtomKind::Eq,
+                positive: true,
+            });
+        }
         _ => {
             // Any other top-level shape (Or/Not/Distinct/Ite/…) belongs to the
             // boolean abstraction layer, not to this pure-conjunction fast
@@ -502,9 +617,12 @@ pub fn dispatch_nia_constraints(
     if !has_nl && !has_divmod {
         return None;
     }
-    let has_unsupported_ops = assertions
-        .iter()
-        .any(|&a| contains_non_polynomial_ops(a, manager));
+    // Unsupported ops only count on the *arithmetic* fragment. Array
+    // `store` trees that only appear in array-sorted equalities are not
+    // part of that fragment (see `is_array_structural_eq`).
+    let has_unsupported_ops = assertions.iter().any(|&a| {
+        !assertion_is_array_only(a, manager) && contains_non_polynomial_ops(a, manager)
+    });
 
     let config = NiaConfig {
         enable_cutting_planes: true,
@@ -516,6 +634,9 @@ pub fn dispatch_nia_constraints(
     let mut poly_atoms: Vec<PolyAtom> = Vec::new();
     let mut incomplete = false;
     for &assertion in assertions {
+        if assertion_is_array_only(assertion, manager) {
+            continue;
+        }
         extract_poly_atoms(
             assertion,
             manager,
@@ -534,18 +655,11 @@ pub fn dispatch_nia_constraints(
         return None;
     }
 
-    // Unsat from NiaSolver is sound whenever extraction saw the full assertion
-    // set as polynomial atoms (no dropped disjunctions / incomplete div-mod).
-    // Multivariate CAD/B&B unsat is trustworthy under that completeness
-    // condition: a false unsat from greedy cell failure was fixed by arithmetic
-    // re-sampling in `oxiz-nlsat` (bare `x*y=c` no longer collapses to Unsat).
-    let unsat_is_trustworthy = !has_unsupported_ops && !incomplete;
-    // A `Sat` verdict is only sound when the solver saw the *entire* assertion
-    // set as a conjunction of translatable atoms. If any top-level term was
-    // dropped (a disjunction, an untranslatable operand, …) the solver worked
-    // on a strictly weaker problem, so its model may violate the dropped
-    // constraint — fall through to CDCL(T) instead of trusting Sat.
-    let sat_is_trustworthy = !incomplete;
+    // Unsat of the pure arith fragment is always sound for the full problem
+    // (more constraints can only shrink the model set). Sat is sound when
+    // extraction did not drop any non-array constraint.
+    let unsat_is_trustworthy = true;
+    let sat_is_trustworthy = !incomplete && !has_unsupported_ops;
 
     for atom in &poly_atoms {
         let atom_id = translator
@@ -626,6 +740,16 @@ impl<'a> RealPolyTranslator<'a> {
                     acc = Polynomial::mul(&acc, &p);
                 }
                 Some(acc)
+            }
+            TermKind::Select(_, _) | TermKind::Apply { .. } => {
+                let term = self.manager.get(term_id)?;
+                let int_s = self.manager.sorts.int_sort;
+                let real_s = self.manager.sorts.real_sort;
+                if term.sort != int_s && term.sort != real_s {
+                    return None;
+                }
+                let v = self.get_or_create_var(term_id);
+                Some(Polynomial::from_var(v))
             }
             _ => None,
         }

--- a/oxiz-theories/src/nlsat.rs
+++ b/oxiz-theories/src/nlsat.rs
@@ -23,7 +23,7 @@ use crate::prelude::*;
 use crate::theory::{Theory, TheoryId, TheoryResult};
 use num_bigint::BigInt;
 use num_rational::BigRational;
-use num_traits::ToPrimitive;
+use num_traits::{ToPrimitive, Zero};
 use oxiz_core::ast::{TermId, TermKind, TermManager};
 use oxiz_core::error::Result;
 use oxiz_math::polynomial::Polynomial;
@@ -57,11 +57,22 @@ pub enum NlDispatchResult {
 ///
 /// Maintains a cache of `TermId → polynomial variable index` so that each
 /// unique variable term receives a stable index.
+///
+/// Integer `div`/`mod` are encoded with fresh quotient/remainder variables and
+/// the Euclidean identities `a = q·b + r`, `0 ≤ r < |b|` (constant positive
+/// divisors only for the strict upper bound; otherwise extraction is marked
+/// incomplete). Side-constraint atoms are buffered in [`Self::pending_atoms`].
 pub struct TermPolyTranslator<'a> {
     manager: &'a TermManager,
     nlsat: &'a mut NiaSolver,
     var_cache: HashMap<TermId, u32>,
     integer_mode: bool,
+    /// Fresh poly var for each `(div a b)` / `(mod a b)` term pair key.
+    divmod_cache: HashMap<(TermId, TermId), (u32, u32)>,
+    /// Side constraints emitted while translating div/mod.
+    pending_atoms: Vec<PolyAtom>,
+    /// Set when a div/mod could not be fully encoded (non-constant divisor, …).
+    divmod_incomplete: bool,
 }
 
 impl<'a> TermPolyTranslator<'a> {
@@ -72,13 +83,16 @@ impl<'a> TermPolyTranslator<'a> {
             nlsat,
             var_cache: HashMap::new(),
             integer_mode,
+            divmod_cache: HashMap::new(),
+            pending_atoms: Vec::new(),
+            divmod_incomplete: false,
         }
     }
 
     /// Translate a term into a `Polynomial`.
     ///
     /// Returns `None` for sub-expressions that cannot be expressed as a
-    /// polynomial (e.g. division, modulo, uninterpreted functions).
+    /// polynomial (e.g. uninterpreted functions, non-constant real division).
     pub fn translate(&mut self, term_id: TermId) -> Option<Polynomial> {
         let term = self.manager.get(term_id)?;
         match &term.kind.clone() {
@@ -122,8 +136,88 @@ impl<'a> TermPolyTranslator<'a> {
                 }
                 Some(acc)
             }
+            TermKind::Div(lhs, rhs) | TermKind::Mod(lhs, rhs) => {
+                let (q, r) = self.ensure_divmod(*lhs, *rhs)?;
+                match &term.kind {
+                    TermKind::Div(_, _) => Some(Polynomial::from_var(q)),
+                    _ => Some(Polynomial::from_var(r)),
+                }
+            }
             _ => None,
         }
+    }
+
+    /// Ensure Euclidean `div`/`mod` witnesses for `(lhs, rhs)`.
+    ///
+    /// Emits `lhs = q·rhs + r` and, when `rhs` is a positive integer constant
+    /// `b`, `0 ≤ r < b`. Returns `(q_var, r_var)`.
+    fn ensure_divmod(&mut self, lhs: TermId, rhs: TermId) -> Option<(u32, u32)> {
+        if let Some(&pair) = self.divmod_cache.get(&(lhs, rhs)) {
+            return Some(pair);
+        }
+        let a = self.translate(lhs)?;
+        let b_poly = self.translate(rhs)?;
+
+        let q = self.nlsat.nlsat_mut().new_arith_var();
+        let r = self.nlsat.nlsat_mut().new_arith_var();
+        if self.integer_mode {
+            self.nlsat.set_var_type(q, VarType::Integer);
+            self.nlsat.set_var_type(r, VarType::Integer);
+        } else {
+            // Sort-based: div/mod are integer ops in SMT-LIB.
+            self.nlsat.set_var_type(q, VarType::Integer);
+            self.nlsat.set_var_type(r, VarType::Integer);
+        }
+
+        let q_poly = Polynomial::from_var(q);
+        let r_poly = Polynomial::from_var(r);
+        // a - (q*b + r) = 0
+        let qb = Polynomial::mul(&q_poly, &b_poly);
+        let qb_r = Polynomial::add(&qb, &r_poly);
+        self.pending_atoms.push(PolyAtom {
+            poly: Polynomial::sub(&a, &qb_r),
+            kind: AtomKind::Eq,
+            positive: true,
+        });
+        // r >= 0  ⇔  NOT(r < 0)
+        self.pending_atoms.push(PolyAtom {
+            poly: r_poly.clone(),
+            kind: AtomKind::Lt,
+            positive: false,
+        });
+
+        // 0 ≤ r < |b|. For constant b use a linear bound; for variable b use
+        // the polynomial encoding r² < b² (equivalent under r ≥ 0, b ≠ 0).
+        if b_poly.is_constant() {
+            let b_const = b_poly.constant_value();
+            if b_const.is_zero() {
+                self.divmod_incomplete = true;
+                return None;
+            }
+            let abs_b = if b_const < BigRational::zero() {
+                -b_const
+            } else {
+                b_const
+            };
+            // r - |b| < 0  ⇔  r < |b|
+            self.pending_atoms.push(PolyAtom {
+                poly: Polynomial::sub(&r_poly, &Polynomial::constant(abs_b)),
+                kind: AtomKind::Lt,
+                positive: true,
+            });
+        } else {
+            // r*r - b*b < 0
+            let r2 = Polynomial::mul(&r_poly, &r_poly);
+            let b2 = Polynomial::mul(&b_poly, &b_poly);
+            self.pending_atoms.push(PolyAtom {
+                poly: Polynomial::sub(&r2, &b2),
+                kind: AtomKind::Lt,
+                positive: true,
+            });
+        }
+
+        self.divmod_cache.insert((lhs, rhs), (q, r));
+        Some((q, r))
     }
 
     fn get_or_create_var(&mut self, term_id: TermId) -> u32 {
@@ -197,13 +291,48 @@ fn is_const_term(term_id: TermId, manager: &TermManager) -> bool {
         .unwrap_or(false)
 }
 
+fn term_contains_divmod(term_id: TermId, manager: &TermManager) -> bool {
+    let Some(term) = manager.get(term_id) else {
+        return false;
+    };
+    match &term.kind {
+        TermKind::Div(_, _) | TermKind::Mod(_, _) => true,
+        TermKind::Neg(inner) | TermKind::Not(inner) => term_contains_divmod(*inner, manager),
+        TermKind::Add(args)
+        | TermKind::Mul(args)
+        | TermKind::And(args)
+        | TermKind::Or(args)
+        | TermKind::Distinct(args) => args.iter().any(|&a| term_contains_divmod(a, manager)),
+        TermKind::Ite(c, t, e) => {
+            term_contains_divmod(*c, manager)
+                || term_contains_divmod(*t, manager)
+                || term_contains_divmod(*e, manager)
+        }
+        TermKind::Xor(a, b)
+        | TermKind::Implies(a, b)
+        | TermKind::Sub(a, b)
+        | TermKind::Eq(a, b)
+        | TermKind::Gt(a, b)
+        | TermKind::Ge(a, b)
+        | TermKind::Lt(a, b)
+        | TermKind::Le(a, b) => {
+            term_contains_divmod(*a, manager) || term_contains_divmod(*b, manager)
+        }
+        _ => false,
+    }
+}
+
 fn contains_non_polynomial_ops(term_id: TermId, manager: &TermManager) -> bool {
     let Some(term) = manager.get(term_id) else {
         return false;
     };
 
     match &term.kind {
-        TermKind::Div(_, _) | TermKind::Mod(_, _) => true,
+        // Div/Mod are encoded via Euclidean auxiliaries in the NIA translator
+        // when the divisor is a nonzero constant; still walk children.
+        TermKind::Div(lhs, rhs) | TermKind::Mod(lhs, rhs) => {
+            contains_non_polynomial_ops(*lhs, manager) || contains_non_polynomial_ops(*rhs, manager)
+        }
         TermKind::Apply { .. }
         | TermKind::Forall { .. }
         | TermKind::Exists { .. }
@@ -367,7 +496,10 @@ pub fn dispatch_nia_constraints(
     integer_mode: bool,
 ) -> Option<NlDispatchResult> {
     let has_nl = assertions.iter().any(|&a| term_is_nonlinear(a, manager));
-    if !has_nl {
+    let has_divmod = assertions.iter().any(|&a| term_contains_divmod(a, manager));
+    // Engage for nonlinear products *or* integer div/mod (encoded via
+    // Euclidean auxiliaries below). Pure linear problems stay with LIA.
+    if !has_nl && !has_divmod {
         return None;
     }
     let has_unsupported_ops = assertions
@@ -392,13 +524,22 @@ pub fn dispatch_nia_constraints(
             &mut incomplete,
         );
     }
+    // Euclidean div/mod side constraints collected during translation.
+    poly_atoms.extend(translator.pending_atoms.iter().cloned());
+    if translator.divmod_incomplete {
+        incomplete = true;
+    }
 
     if poly_atoms.is_empty() {
         return None;
     }
 
-    let unsat_is_trustworthy =
-        !has_unsupported_ops && poly_atoms.iter().all(|atom| atom.poly.is_univariate());
+    // Unsat from NiaSolver is sound whenever extraction saw the full assertion
+    // set as polynomial atoms (no dropped disjunctions / incomplete div-mod).
+    // Multivariate CAD/B&B unsat is trustworthy under that completeness
+    // condition: a false unsat from greedy cell failure was fixed by arithmetic
+    // re-sampling in `oxiz-nlsat` (bare `x*y=c` no longer collapses to Unsat).
+    let unsat_is_trustworthy = !has_unsupported_ops && !incomplete;
     // A `Sat` verdict is only sound when the solver saw the *entire* assertion
     // set as a conjunction of translatable atoms. If any top-level term was
     // dropped (a disjunction, an untranslatable operand, …) the solver worked

--- a/oxiz-theories/src/nlsat.rs
+++ b/oxiz-theories/src/nlsat.rs
@@ -305,7 +305,7 @@ pub fn term_is_nonlinear(term_id: TermId, manager: &TermManager) -> bool {
             }
             args.iter().any(|&a| term_is_nonlinear(a, manager))
         }
-        TermKind::Add(args) | TermKind::And(args) => {
+        TermKind::Add(args) | TermKind::And(args) | TermKind::Or(args) => {
             args.iter().any(|&a| term_is_nonlinear(a, manager))
         }
         TermKind::Sub(lhs, rhs)
@@ -313,10 +313,27 @@ pub fn term_is_nonlinear(term_id: TermId, manager: &TermManager) -> bool {
         | TermKind::Gt(lhs, rhs)
         | TermKind::Ge(lhs, rhs)
         | TermKind::Lt(lhs, rhs)
-        | TermKind::Le(lhs, rhs) => {
+        | TermKind::Le(lhs, rhs)
+        | TermKind::Div(lhs, rhs)
+        | TermKind::Mod(lhs, rhs)
+        | TermKind::Implies(lhs, rhs)
+        | TermKind::Xor(lhs, rhs) => {
             term_is_nonlinear(*lhs, manager) || term_is_nonlinear(*rhs, manager)
         }
-        TermKind::Neg(inner) => term_is_nonlinear(*inner, manager),
+        TermKind::Neg(inner) | TermKind::Not(inner) => term_is_nonlinear(*inner, manager),
+        // Industrial QF_NIA nests products under `let`/`ite` (calypto VCs).
+        // Missing these arms skipped NIA dispatch entirely → CDCL sat (soundness).
+        TermKind::Ite(c, t, e) => {
+            term_is_nonlinear(*c, manager)
+                || term_is_nonlinear(*t, manager)
+                || term_is_nonlinear(*e, manager)
+        }
+        TermKind::Let { bindings, body } => {
+            bindings
+                .iter()
+                .any(|&(_, v)| term_is_nonlinear(v, manager))
+                || term_is_nonlinear(*body, manager)
+        }
         _ => false,
     }
 }
@@ -344,6 +361,12 @@ fn term_contains_divmod(term_id: TermId, manager: &TermManager) -> bool {
             term_contains_divmod(*c, manager)
                 || term_contains_divmod(*t, manager)
                 || term_contains_divmod(*e, manager)
+        }
+        TermKind::Let { bindings, body } => {
+            bindings
+                .iter()
+                .any(|&(_, v)| term_contains_divmod(v, manager))
+                || term_contains_divmod(*body, manager)
         }
         TermKind::Xor(a, b)
         | TermKind::Implies(a, b)
@@ -397,10 +420,15 @@ fn contains_non_polynomial_ops(term_id: TermId, manager: &TermManager) -> bool {
                 || contains_non_polynomial_ops(*i, manager)
                 || contains_non_polynomial_ops(*v, manager)
         }
-        TermKind::Forall { .. }
-        | TermKind::Exists { .. }
-        | TermKind::Let { .. }
-        | TermKind::Match { .. } => true,
+        TermKind::Forall { .. } | TermKind::Exists { .. } | TermKind::Match { .. } => true,
+        // `let` is binding sugar; walk the body (parser already inlines binding
+        // TermIds into the body DAG).
+        TermKind::Let { bindings, body } => {
+            bindings
+                .iter()
+                .any(|&(_, v)| contains_non_polynomial_ops(v, manager))
+                || contains_non_polynomial_ops(*body, manager)
+        }
         TermKind::Neg(inner) | TermKind::Not(inner) => contains_non_polynomial_ops(*inner, manager),
         TermKind::Add(args)
         | TermKind::Mul(args)
@@ -595,6 +623,90 @@ fn extract_poly_atoms(
                 extract_poly_atoms(arg, manager, translator, out, incomplete);
             }
         }
+        // Negated comparisons from ite-condition case-split: ¬(a < b) ≡ a ≥ b, etc.
+        TermKind::Not(inner) => {
+            let Some(inner_t) = manager.get(*inner) else {
+                *incomplete = true;
+                return;
+            };
+            match &inner_t.kind.clone() {
+                TermKind::Lt(lhs, rhs) => {
+                    // ¬(lhs < rhs) ≡ lhs ≥ rhs ≡ ¬(lhs - rhs < 0)
+                    if let (Some(lp), Some(rp)) =
+                        (translator.translate(*lhs), translator.translate(*rhs))
+                    {
+                        out.push(PolyAtom {
+                            poly: Polynomial::sub(&lp, &rp),
+                            kind: AtomKind::Lt,
+                            positive: false,
+                        });
+                    } else {
+                        *incomplete = true;
+                    }
+                }
+                TermKind::Le(lhs, rhs) => {
+                    // ¬(lhs ≤ rhs) ≡ lhs > rhs
+                    if let (Some(lp), Some(rp)) =
+                        (translator.translate(*lhs), translator.translate(*rhs))
+                    {
+                        out.push(PolyAtom {
+                            poly: Polynomial::sub(&lp, &rp),
+                            kind: AtomKind::Gt,
+                            positive: true,
+                        });
+                    } else {
+                        *incomplete = true;
+                    }
+                }
+                TermKind::Gt(lhs, rhs) => {
+                    // ¬(lhs > rhs) ≡ lhs ≤ rhs ≡ ¬(lhs - rhs < 0) wait: lhs ≤ rhs ≡ ¬(lhs - rhs > 0)
+                    // use ¬(lhs - rhs > 0) as NOT Gt → Le: poly lhs-rhs, Lt positive false? 
+                    // lhs ≤ rhs → rhs - lhs ≥ 0 → NOT(rhs - lhs < 0)
+                    if let (Some(lp), Some(rp)) =
+                        (translator.translate(*lhs), translator.translate(*rhs))
+                    {
+                        out.push(PolyAtom {
+                            poly: Polynomial::sub(&rp, &lp),
+                            kind: AtomKind::Lt,
+                            positive: false,
+                        });
+                    } else {
+                        *incomplete = true;
+                    }
+                }
+                TermKind::Ge(lhs, rhs) => {
+                    // ¬(lhs ≥ rhs) ≡ lhs < rhs → rhs - lhs > 0
+                    if let (Some(lp), Some(rp)) =
+                        (translator.translate(*lhs), translator.translate(*rhs))
+                    {
+                        out.push(PolyAtom {
+                            poly: Polynomial::sub(&rp, &lp),
+                            kind: AtomKind::Gt,
+                            positive: true,
+                        });
+                    } else {
+                        *incomplete = true;
+                    }
+                }
+                TermKind::Eq(lhs, rhs) => {
+                    // ¬(a = b) is a disequality — incomplete for pure conjunction.
+                    let _ = (lhs, rhs);
+                    *incomplete = true;
+                }
+                TermKind::Not(inner2) => {
+                    // ¬¬φ ≡ φ
+                    extract_poly_atoms(*inner2, manager, translator, out, incomplete);
+                }
+                _ => {
+                    *incomplete = true;
+                }
+            }
+        }
+        // Parser builds Let with body already referencing binding TermIds;
+        // still walk the body (bindings are shared structure inside body).
+        TermKind::Let { body, .. } => {
+            extract_poly_atoms(*body, manager, translator, out, incomplete);
+        }
         // Interface equalities that collapsed to reflexivity after purification
         // (`c = c`) are no-ops for the arithmetic fragment.
         TermKind::True => {}
@@ -621,6 +733,10 @@ fn extract_poly_atoms(
 // NIA dispatch: public entry point
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// Max free Boolean variables for exhaustive case-split before NIA.
+/// 6 → 64 cases; enough for calypto-style VCs with a handful of flags.
+const NIA_MAX_BOOL_CASESPLIT: usize = 6;
+
 /// Dispatch nonlinear integer arithmetic assertions to the `NiaSolver`.
 ///
 /// Returns:
@@ -629,9 +745,13 @@ fn extract_poly_atoms(
 /// - `None` if translation yields no atoms or the solver returns Unknown.
 ///
 /// Both linear and nonlinear assertions are passed so the solver has full context.
+///
+/// When free Boolean variables appear (common in industrial QF_NIA with `ite`),
+/// exhaustively case-splits them (up to [`NIA_MAX_BOOL_CASESPLIT`]) and
+/// simplifies each branch so nested `ite`s collapse before polynomial extract.
 pub fn dispatch_nia_constraints(
     assertions: &[TermId],
-    manager: &TermManager,
+    manager: &mut TermManager,
     integer_mode: bool,
 ) -> Option<NlDispatchResult> {
     let has_nl = assertions.iter().any(|&a| term_is_nonlinear(a, manager));
@@ -641,6 +761,7 @@ pub fn dispatch_nia_constraints(
     if !has_nl && !has_divmod {
         return None;
     }
+    let bools = free_bool_vars(assertions, manager);
 
     // Ground store-chains + finite index boxes: decide by evaluating selects
     // (sound for QF_ANIA). Runs before the pure-arith relaxation so we never
@@ -651,9 +772,323 @@ pub fn dispatch_nia_constraints(
         return Some(r);
     }
 
-    // Unsupported ops only count on the *arithmetic* fragment. Array
-    // `store` trees that only appear in array-sorted equalities are not
-    // part of that fragment (see `is_array_structural_eq`).
+    if !bools.is_empty() && bools.len() <= NIA_MAX_BOOL_CASESPLIT {
+        return dispatch_nia_bool_cases(assertions, manager, integer_mode, &bools);
+    }
+
+    dispatch_nia_core(assertions, manager, integer_mode)
+}
+
+/// Free Boolean-sorted variables appearing in `assertions`.
+fn free_bool_vars(assertions: &[TermId], manager: &TermManager) -> Vec<TermId> {
+    let mut out = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    let mut stack: Vec<TermId> = assertions.to_vec();
+    while let Some(id) = stack.pop() {
+        if !seen.insert(id) {
+            continue;
+        }
+        let Some(t) = manager.get(id) else {
+            continue;
+        };
+        if matches!(t.kind, TermKind::Var(_)) && t.sort == manager.sorts.bool_sort {
+            out.push(id);
+            continue;
+        }
+        // Structural children
+        match &t.kind {
+            TermKind::Not(a) | TermKind::Neg(a) => stack.push(*a),
+            TermKind::And(xs) | TermKind::Or(xs) | TermKind::Add(xs) | TermKind::Mul(xs) => {
+                stack.extend(xs.iter().copied());
+            }
+            TermKind::Ite(c, a, b) => {
+                stack.push(*c);
+                stack.push(*a);
+                stack.push(*b);
+            }
+            TermKind::Eq(a, b)
+            | TermKind::Lt(a, b)
+            | TermKind::Le(a, b)
+            | TermKind::Gt(a, b)
+            | TermKind::Ge(a, b)
+            | TermKind::Sub(a, b)
+            | TermKind::Div(a, b)
+            | TermKind::Mod(a, b)
+            | TermKind::Implies(a, b)
+            | TermKind::Xor(a, b) => {
+                stack.push(*a);
+                stack.push(*b);
+            }
+            TermKind::Let { bindings, body } => {
+                for &(_, v) in bindings.iter() {
+                    stack.push(v);
+                }
+                stack.push(*body);
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+/// Exhaustive Boolean case-split then core NIA on each simplified branch.
+fn dispatch_nia_bool_cases(
+    assertions: &[TermId],
+    manager: &mut TermManager,
+    integer_mode: bool,
+    bools: &[TermId],
+) -> Option<NlDispatchResult> {
+    let n = bools.len();
+    let cases = 1u32 << n;
+    let mut all_unsat = true;
+    let mut saw_decisive = false;
+    let mut sat_result: Option<NlDispatchResult> = None;
+
+    for mask in 0..cases {
+        let mut subst: FxHashMap<TermId, TermId> = FxHashMap::default();
+        for (i, &b) in bools.iter().enumerate() {
+            let val = if (mask >> i) & 1 == 1 {
+                manager.mk_true()
+            } else {
+                manager.mk_false()
+            };
+            subst.insert(b, val);
+        }
+        let simplified: Vec<TermId> = assertions
+            .iter()
+            .map(|&a| {
+                let s = manager.substitute(a, &subst);
+                manager.simplify(s)
+            })
+            .collect();
+        // Drop trivial true asserts; false assert → this case unsat.
+        if simplified.iter().any(|&a| {
+            manager
+                .get(a)
+                .is_some_and(|t| matches!(t.kind, TermKind::False))
+        }) {
+            saw_decisive = true;
+            continue;
+        }
+        let filtered: Vec<TermId> = simplified
+            .into_iter()
+            .filter(|&a| {
+                !manager
+                    .get(a)
+                    .is_some_and(|t| matches!(t.kind, TermKind::True))
+            })
+            .collect();
+
+        match dispatch_nia_core(&filtered, manager, integer_mode) {
+            Some(r @ NlDispatchResult::Sat(_)) => {
+                sat_result = Some(r);
+                break;
+            }
+            Some(NlDispatchResult::Unsat) => {
+                saw_decisive = true;
+            }
+            None => {
+                all_unsat = false;
+            }
+        }
+    }
+
+    if let Some(r) = sat_result {
+        return Some(r);
+    }
+    if all_unsat && saw_decisive {
+        return Some(NlDispatchResult::Unsat);
+    }
+    None
+}
+
+/// Core NIA path without Boolean case-split.
+///
+/// When assertions still contain numeric `ite`, expands them by case-splitting
+/// on each `ite` condition (up to a budget) so the polynomial layer sees
+/// ite-free conjunctions.  Unsat on every expansion branch ⇒ Unsat.
+fn dispatch_nia_core(
+    assertions: &[TermId],
+    manager: &mut TermManager,
+    integer_mode: bool,
+) -> Option<NlDispatchResult> {
+    // Expand numeric ite by branching on conditions.
+    let branches = expand_ite_branches(assertions, manager, 16);
+    if branches.is_empty() {
+        return None;
+    }
+    let mut all_unsat = true;
+    let mut saw_unsat = false;
+    let mut sat_result = None;
+    for branch in &branches {
+        match dispatch_nia_poly_only(branch, manager, integer_mode) {
+            Some(r @ NlDispatchResult::Sat(_)) => {
+                if false {
+                }
+                sat_result = Some(r);
+                break;
+            }
+            Some(NlDispatchResult::Unsat) => {
+                saw_unsat = true;
+            }
+            None => {
+                if false {
+                }
+                all_unsat = false;
+            }
+        }
+    }
+    if let Some(r) = sat_result {
+        return Some(r);
+    }
+    if all_unsat && saw_unsat {
+        return Some(NlDispatchResult::Unsat);
+    }
+    None
+}
+
+/// Expand assertions into ite-free branches by splitting on `ite` conditions.
+///
+/// Each branch is a list of assertions: the original formulas with ites
+/// substituted to a chosen arm, plus the condition (or its negation) that
+/// justified the choice.  Budget limits total branches.
+fn expand_ite_branches(
+    assertions: &[TermId],
+    manager: &mut TermManager,
+    max_depth: u32,
+) -> Vec<Vec<TermId>> {
+    // Start with one branch = input assertions.
+    let mut frontier: Vec<Vec<TermId>> = vec![assertions.to_vec()];
+    for _ in 0..max_depth {
+        let mut next = Vec::new();
+        let mut progressed = false;
+        for branch in frontier {
+            // Find first ite in any assertion.
+            let mut ite_term: Option<TermId> = None;
+            'find: for &a in &branch {
+                let mut st = vec![a];
+                let mut seen = HashSet::new();
+                while let Some(id) = st.pop() {
+                    if !seen.insert(id) {
+                        continue;
+                    }
+                    let Some(t) = manager.get(id) else {
+                        continue;
+                    };
+                    match &t.kind {
+                        TermKind::Ite(_, _, _) => {
+                            // Only split numeric or bool ites that appear in arith context.
+                            ite_term = Some(id);
+                            break 'find;
+                        }
+                        TermKind::Not(x) | TermKind::Neg(x) => st.push(*x),
+                        TermKind::And(xs) | TermKind::Or(xs) | TermKind::Add(xs) | TermKind::Mul(xs) => {
+                            st.extend(xs.iter().copied());
+                        }
+                        TermKind::Eq(a, b)
+                        | TermKind::Lt(a, b)
+                        | TermKind::Le(a, b)
+                        | TermKind::Gt(a, b)
+                        | TermKind::Ge(a, b)
+                        | TermKind::Sub(a, b)
+                        | TermKind::Div(a, b)
+                        | TermKind::Mod(a, b)
+                        | TermKind::Implies(a, b)
+                        | TermKind::Xor(a, b) => {
+                            st.push(*a);
+                            st.push(*b);
+                        }
+                        TermKind::Let { body, bindings } => {
+                            st.push(*body);
+                            for &(_, v) in bindings.iter() {
+                                st.push(v);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            let Some(ite_id) = ite_term else {
+                next.push(branch);
+                continue;
+            };
+            progressed = true;
+            let (c, t_arm, e_arm) = match manager.get(ite_id).map(|n| n.kind.clone()) {
+                Some(TermKind::Ite(c, t, e)) => (c, t, e),
+                _ => {
+                    next.push(branch);
+                    continue;
+                }
+            };
+            // Branch then: assume c, replace ite with t_arm
+            {
+                let mut subst = FxHashMap::default();
+                subst.insert(ite_id, t_arm);
+                let mut b1: Vec<TermId> = branch
+                    .iter()
+                    .map(|&a| {
+                        let s = manager.substitute(a, &subst);
+                        manager.simplify(s)
+                    })
+                    .collect();
+                b1.push(c); // condition holds
+                next.push(b1);
+            }
+            // Branch else: assume ¬c, replace ite with e_arm
+            {
+                let mut subst = FxHashMap::default();
+                subst.insert(ite_id, e_arm);
+                let not_c = manager.mk_not(c);
+                let mut b2: Vec<TermId> = branch
+                    .iter()
+                    .map(|&a| {
+                        let s = manager.substitute(a, &subst);
+                        manager.simplify(s)
+                    })
+                    .collect();
+                b2.push(not_c);
+                next.push(b2);
+            }
+            // Cap explosion
+            if next.len() > 4096 {
+                return Vec::new(); // give up → Unknown
+            }
+        }
+        frontier = next;
+        if !progressed {
+            break;
+        }
+    }
+    // Filter trivial
+    frontier
+        .into_iter()
+        .filter_map(|branch| {
+            if branch.iter().any(|&a| {
+                manager
+                    .get(a)
+                    .is_some_and(|t| matches!(t.kind, TermKind::False))
+            }) {
+                return None; // inconsistent branch
+            }
+            let b: Vec<_> = branch
+                .into_iter()
+                .filter(|&a| {
+                    !manager
+                        .get(a)
+                        .is_some_and(|t| matches!(t.kind, TermKind::True))
+                })
+                .collect();
+            Some(b)
+        })
+        .collect()
+}
+
+/// Pure polynomial NIA on ite-free (or residual) assertions.
+fn dispatch_nia_poly_only(
+    assertions: &[TermId],
+    manager: &TermManager,
+    integer_mode: bool,
+) -> Option<NlDispatchResult> {
     let has_unsupported_ops = assertions.iter().any(|&a| {
         !assertion_is_array_only(a, manager) && contains_non_polynomial_ops(a, manager)
     });
@@ -662,6 +1097,9 @@ pub fn dispatch_nia_constraints(
 
     let config = NiaConfig {
         enable_cutting_planes: true,
+        // Industrial QF_NIA (calypto) needs a deeper B&B than the nlsat default.
+        max_nodes: 100_000,
+        max_depth: 256,
         ..NiaConfig::default()
     };
     let mut nia = NiaSolver::with_config(config);
@@ -673,6 +1111,7 @@ pub fn dispatch_nia_constraints(
         if assertion_is_array_only(assertion, manager) {
             continue;
         }
+        // Push Boolean conditions that are arithmetic comparisons as atoms.
         extract_poly_atoms(
             assertion,
             manager,
@@ -681,20 +1120,19 @@ pub fn dispatch_nia_constraints(
             &mut incomplete,
         );
     }
-    // Euclidean div/mod side constraints collected during translation.
     poly_atoms.extend(translator.pending_atoms.iter().cloned());
     if translator.divmod_incomplete {
         incomplete = true;
     }
 
     if poly_atoms.is_empty() {
+        // Empty branch after filtering = vacuously sat (no arith constraints).
+        if !incomplete && !has_unsupported_ops {
+            return Some(NlDispatchResult::sat_empty());
+        }
         return None;
     }
 
-    // Unsat of the pure arith *relaxation* is always sound (extra array
-    // constraints can only remove models). Sat is sound only when we did not
-    // drop anything and there are no store-definitions that further constrain
-    // purified select constants — otherwise free select-vars over-approx.
     let unsat_is_trustworthy = true;
     let sat_is_trustworthy = !incomplete && !has_unsupported_ops && !has_array_stores;
 
@@ -710,7 +1148,8 @@ pub fn dispatch_nia_constraints(
         translator.nlsat.nlsat_mut().add_clause(vec![lit]);
     }
 
-    match translator.nlsat.solve() {
+    let solved = translator.nlsat.solve();
+    match solved {
         SolverResult::Sat if sat_is_trustworthy => {
             let model = extract_nia_model(&translator);
             Some(NlDispatchResult::sat_with(model))
@@ -1346,7 +1785,7 @@ mod tests {
         let square = manager.mk_mul(vec![x, x]);
         let four = manager.mk_int(4);
         let eq = manager.mk_eq(square, four);
-        let result = dispatch_nia_constraints(&[eq], &manager, true);
+        let result = dispatch_nia_constraints(&[eq], &mut manager, true);
         // SAT or Unknown (unknown means solver fell through)
         assert!(
             matches!(result, Some(NlDispatchResult::Sat(_)) | None),
@@ -1364,7 +1803,7 @@ mod tests {
         let square = manager.mk_mul(vec![x, x]);
         let neg_one = manager.mk_int(-1);
         let eq = manager.mk_eq(square, neg_one);
-        let result = dispatch_nia_constraints(&[eq], &manager, true);
+        let result = dispatch_nia_constraints(&[eq], &mut manager, true);
         assert!(
             matches!(result, Some(NlDispatchResult::Unsat) | None),
             "x*x=-1 should be UNSAT or unknown, got {:?}",

--- a/oxiz-theories/src/nlsat.rs
+++ b/oxiz-theories/src/nlsat.rs
@@ -36,16 +36,40 @@ use std::collections::HashMap;
 // Public result type for dispatch functions
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// Concrete arithmetic assignment produced by a nonlinear decision procedure.
+///
+/// Keys are free arithmetic terms (`Var`, purified `select` constants, …);
+/// values are the rational witnesses found by NIA/NRA/ANIA ground search.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct NlSatModel {
+    /// TermId → rational value for every free arithmetic variable assigned.
+    pub assignments: HashMap<TermId, BigRational>,
+}
+
 /// The definitive result from a nonlinear dispatch call.
 ///
 /// `Unknown` is not included: `dispatch_*` functions return `None` to signal
 /// "fall through to CDCL(T)" instead of wrapping Unknown.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NlDispatchResult {
-    /// The constraint set is satisfiable.
-    Sat,
+    /// The constraint set is satisfiable, with a concrete model witness.
+    Sat(NlSatModel),
     /// The constraint set is unsatisfiable.
     Unsat,
+}
+
+impl NlDispatchResult {
+    /// Satisfiable with an empty assignment map (defaults fill gaps).
+    #[must_use]
+    pub fn sat_empty() -> Self {
+        Self::Sat(NlSatModel::default())
+    }
+
+    /// Satisfiable with the given term→value map.
+    #[must_use]
+    pub fn sat_with(assignments: HashMap<TermId, BigRational>) -> Self {
+        Self::Sat(NlSatModel { assignments })
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -601,7 +625,7 @@ fn extract_poly_atoms(
 ///
 /// Returns:
 /// - `Some(NlDispatchResult::Unsat)` if the system is provably UNSAT,
-/// - `Some(NlDispatchResult::Sat)` if NiaSolver finds an integer model,
+/// - `Some(NlDispatchResult::Sat(_))` if NiaSolver finds an integer model,
 /// - `None` if translation yields no atoms or the solver returns Unknown.
 ///
 /// Both linear and nonlinear assertions are passed so the solver has full context.
@@ -687,10 +711,27 @@ pub fn dispatch_nia_constraints(
     }
 
     match translator.nlsat.solve() {
-        SolverResult::Sat if sat_is_trustworthy => Some(NlDispatchResult::Sat),
+        SolverResult::Sat if sat_is_trustworthy => {
+            let model = extract_nia_model(&translator);
+            Some(NlDispatchResult::sat_with(model))
+        }
         SolverResult::Unsat if unsat_is_trustworthy => Some(NlDispatchResult::Unsat),
         SolverResult::Sat | SolverResult::Unsat | SolverResult::Unknown => None,
     }
+}
+
+/// Map NIA poly-var indices back to TermIds via the translator cache.
+fn extract_nia_model(translator: &TermPolyTranslator<'_>) -> HashMap<TermId, BigRational> {
+    let mut out = HashMap::new();
+    let Some(nlsat_model) = translator.nlsat.nlsat().get_model() else {
+        return out;
+    };
+    for (&term, &poly_var) in translator.var_cache() {
+        if let Some(val) = nlsat_model.arith_value(poly_var) {
+            out.insert(term, val.clone());
+        }
+    }
+    out
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -776,6 +817,24 @@ impl<'a> RealPolyTranslator<'a> {
         self.var_cache.insert(term_id, v);
         v
     }
+
+    fn var_cache(&self) -> &HashMap<TermId, u32> {
+        &self.var_cache
+    }
+}
+
+/// Map NRA poly-var indices back to TermIds via the translator cache.
+fn extract_nra_model(translator: &RealPolyTranslator<'_>) -> HashMap<TermId, BigRational> {
+    let mut out = HashMap::new();
+    let Some(nlsat_model) = translator.nlsat.get_model() else {
+        return out;
+    };
+    for (&term, &poly_var) in translator.var_cache() {
+        if let Some(val) = nlsat_model.arith_value(poly_var) {
+            out.insert(term, val.clone());
+        }
+    }
+    out
 }
 
 /// Real-arithmetic analogue of [`extract_poly_atoms`]. See its documentation
@@ -899,7 +958,10 @@ pub fn dispatch_nra_constraints(
     }
 
     match translator.nlsat.solve() {
-        SolverResult::Sat if sat_is_trustworthy => Some(NlDispatchResult::Sat),
+        SolverResult::Sat if sat_is_trustworthy => {
+            let model = extract_nra_model(&translator);
+            Some(NlDispatchResult::sat_with(model))
+        }
         SolverResult::Unsat if unsat_is_trustworthy => Some(NlDispatchResult::Unsat),
         SolverResult::Sat | SolverResult::Unsat | SolverResult::Unknown => None,
     }
@@ -1287,7 +1349,7 @@ mod tests {
         let result = dispatch_nia_constraints(&[eq], &manager, true);
         // SAT or Unknown (unknown means solver fell through)
         assert!(
-            matches!(result, Some(NlDispatchResult::Sat) | None),
+            matches!(result, Some(NlDispatchResult::Sat(_)) | None),
             "x*x=4 should be SAT or unknown, got {:?}",
             result
         );

--- a/oxiz-theories/src/nlsat.rs
+++ b/oxiz-theories/src/nlsat.rs
@@ -617,12 +617,24 @@ pub fn dispatch_nia_constraints(
     if !has_nl && !has_divmod {
         return None;
     }
+
+    // Ground store-chains + finite index boxes: decide by evaluating selects
+    // (sound for QF_ANIA). Runs before the pure-arith relaxation so we never
+    // report Sat from free select-vars when stores constrain them.
+    if crate::ania_ground::assertions_contain_store(assertions, manager)
+        && let Some(r) = crate::ania_ground::try_decide_ground_ania(assertions, manager)
+    {
+        return Some(r);
+    }
+
     // Unsupported ops only count on the *arithmetic* fragment. Array
     // `store` trees that only appear in array-sorted equalities are not
     // part of that fragment (see `is_array_structural_eq`).
     let has_unsupported_ops = assertions.iter().any(|&a| {
         !assertion_is_array_only(a, manager) && contains_non_polynomial_ops(a, manager)
     });
+    let has_array_stores =
+        crate::ania_ground::assertions_contain_store(assertions, manager);
 
     let config = NiaConfig {
         enable_cutting_planes: true,
@@ -655,11 +667,12 @@ pub fn dispatch_nia_constraints(
         return None;
     }
 
-    // Unsat of the pure arith fragment is always sound for the full problem
-    // (more constraints can only shrink the model set). Sat is sound when
-    // extraction did not drop any non-array constraint.
+    // Unsat of the pure arith *relaxation* is always sound (extra array
+    // constraints can only remove models). Sat is sound only when we did not
+    // drop anything and there are no store-definitions that further constrain
+    // purified select constants — otherwise free select-vars over-approx.
     let unsat_is_trustworthy = true;
-    let sat_is_trustworthy = !incomplete && !has_unsupported_ops;
+    let sat_is_trustworthy = !incomplete && !has_unsupported_ops && !has_array_stores;
 
     for atom in &poly_atoms {
         let atom_id = translator

--- a/oxiz-theories/tests/ania_nested.rs
+++ b/oxiz-theories/tests/ania_nested.rs
@@ -1,0 +1,39 @@
+use oxiz_core::ast::TermManager;
+use oxiz_core::smtlib::{parse_script, Command};
+use oxiz_theories::ania_ground::try_decide_ground_ania;
+use oxiz_theories::nlsat::NlDispatchResult;
+
+#[test]
+fn nested_ite_select_product_range() {
+    let mut tm = TermManager::new();
+    let script = r#"
+(set-logic QF_ANIA)
+(declare-const i Int)
+(declare-const t Int)
+(declare-const A (Array Int Int))
+(declare-const B (Array Int Int))
+(declare-const C (Array Int Int))
+(declare-const D (Array Int Int))
+(assert (= A (store (store ((as const (Array Int Int)) 0) 1 30) 2 32)))
+(assert (= B (store (store ((as const (Array Int Int)) 0) 1 76) 2 74)))
+(assert (= C (store (store ((as const (Array Int Int)) 0) 1 5) 2 5)))
+(assert (= D (store (store ((as const (Array Int Int)) 0) 1 3) 2 3)))
+(define-fun absi ((x Int)) Int (ite (< x 0) (- x) x))
+(define-fun w ((k Int) (s Int)) Int
+  (let ((d (absi (- s (select C k)))))
+    (ite (<= d (select D k)) 10 (ite (<= d (* 2 (select D k))) 6 0))))
+(assert (and (>= i 1)(<= i 2)(>= t 1)(<= t 9)
+  (>= (* (select A i) (select B i) (w i t) 10) 200000)
+  (<= (* (select A i) (select B i) (w i t) 10) 300000)))
+"#;
+    let cmds = parse_script(script, &mut tm).expect("parse");
+    let asserts: Vec<_> = cmds
+        .into_iter()
+        .filter_map(|c| match c {
+            Command::Assert(t) => Some(t),
+            _ => None,
+        })
+        .collect();
+    let r = try_decide_ground_ania(&asserts, &tm);
+    assert_eq!(r, Some(NlDispatchResult::Sat));
+}

--- a/oxiz-theories/tests/ania_nested.rs
+++ b/oxiz-theories/tests/ania_nested.rs
@@ -35,5 +35,5 @@ fn nested_ite_select_product_range() {
         })
         .collect();
     let r = try_decide_ground_ania(&asserts, &tm);
-    assert_eq!(r, Some(NlDispatchResult::Sat));
+    assert!(matches!(r, Some(NlDispatchResult::Sat(_))));
 }

--- a/oxiz-theories/tests/nlsat_mixed_sort.rs
+++ b/oxiz-theories/tests/nlsat_mixed_sort.rs
@@ -51,11 +51,7 @@ fn test_qf_nira_int_square_with_real_half_is_sat() {
         Some(NlDispatchResult::Unsat),
         "mixed Int/Real (x*x=4 ∧ y=1.5) must not be reported UNSAT — Real y must stay real"
     );
-    assert_eq!(
-        result,
-        Some(NlDispatchResult::Sat),
-        "mixed Int/Real (x*x=4 ∧ y=1.5) is satisfiable (x=±2, y=1.5)"
-    );
+    assert!(matches!(result, Some(NlDispatchResult::Sat(_))), "mixed Int/Real (x*x=4 ∧ y=1.5) is satisfiable (x=±2, y=1.5)");
 }
 
 /// `(* y y) = 4 ∧ 0 < x ∧ x < 1` with `y : Int`, `x : Real`.
@@ -91,11 +87,7 @@ fn test_qf_nira_sat_requires_non_integral_real() {
         Some(NlDispatchResult::Unsat),
         "a Real x in (0,1) must not be rejected as if it were an integer"
     );
-    assert_eq!(
-        result,
-        Some(NlDispatchResult::Sat),
-        "y*y=4 ∧ 0<x<1 is satisfiable (y=±2, x non-integral)"
-    );
+    assert!(matches!(result, Some(NlDispatchResult::Sat(_))), "y*y=4 ∧ 0<x<1 is satisfiable (y=±2, x non-integral)");
 }
 
 /// Control: a *pure* QF_NIA square (all Int) must still be reported SAT — the
@@ -110,11 +102,7 @@ fn test_qf_nia_pure_integer_square_still_sat() {
     let eq = manager.mk_eq(square, four);
 
     let result = dispatch_nia_constraints(&[eq], &manager, true);
-    assert_eq!(
-        result,
-        Some(NlDispatchResult::Sat),
-        "x*x=4 with x:Int is SAT (x=±2)"
-    );
+    assert!(matches!(result, Some(NlDispatchResult::Sat(_))), "x*x=4 with x:Int is SAT (x=±2)");
 }
 
 // ── nia-nra-dispatch-drops-atoms-trusts-sat: no silent drop → no false Sat ───
@@ -144,11 +132,7 @@ fn test_nia_dropped_disjunction_does_not_fabricate_sat() {
 
     let result = dispatch_nia_constraints(&[eq_prod, disj], &manager, true);
 
-    assert_ne!(
-        result,
-        Some(NlDispatchResult::Sat),
-        "a dropped disjunction must not let the relaxed x*y=12 be certified SAT"
-    );
+    assert!(!matches!(result, Some(NlDispatchResult::Sat(_))), "a dropped disjunction must not let the relaxed x*y=12 be certified SAT");
 }
 
 /// NRA: `(* x x) = 4 ∧ (x = 5 ∨ x = 7)` with `x : Real`.
@@ -173,11 +157,7 @@ fn test_nra_dropped_disjunction_does_not_fabricate_sat() {
 
     let result = dispatch_nra_constraints(&[eq_sq, disj], &manager);
 
-    assert_ne!(
-        result,
-        Some(NlDispatchResult::Sat),
-        "a dropped disjunction must not let the relaxed x*x=4 be certified SAT"
-    );
+    assert!(!matches!(result, Some(NlDispatchResult::Sat(_))), "a dropped disjunction must not let the relaxed x*x=4 be certified SAT");
 }
 
 /// NIA: an assertion containing an untranslatable operand (integer `div`) must
@@ -203,9 +183,5 @@ fn test_nia_untranslatable_operand_does_not_fabricate_sat() {
 
     let result = dispatch_nia_constraints(&[eq_sq, eq_div], &manager, true);
 
-    assert_ne!(
-        result,
-        Some(NlDispatchResult::Sat),
-        "an untranslatable div atom must not be dropped into a false SAT"
-    );
+    assert!(!matches!(result, Some(NlDispatchResult::Sat(_))), "an untranslatable div atom must not be dropped into a false SAT");
 }

--- a/oxiz-theories/tests/nlsat_mixed_sort.rs
+++ b/oxiz-theories/tests/nlsat_mixed_sort.rs
@@ -44,7 +44,7 @@ fn test_qf_nira_int_square_with_real_half_is_sat() {
     let eq_y = manager.mk_eq(y, three_halves);
 
     // integer_mode = true mirrors the QF_NIRA routing in the solver.
-    let result = dispatch_nia_constraints(&[eq_sq, eq_y], &manager, true);
+    let result = dispatch_nia_constraints(&[eq_sq, eq_y], &mut manager, true);
 
     assert_ne!(
         result,
@@ -80,7 +80,7 @@ fn test_qf_nira_sat_requires_non_integral_real() {
     let x_gt_0 = manager.mk_gt(x, zero);
     let x_lt_1 = manager.mk_lt(x, one);
 
-    let result = dispatch_nia_constraints(&[eq_y_sq, x_gt_0, x_lt_1], &manager, true);
+    let result = dispatch_nia_constraints(&[eq_y_sq, x_gt_0, x_lt_1], &mut manager, true);
 
     assert_ne!(
         result,
@@ -101,7 +101,7 @@ fn test_qf_nia_pure_integer_square_still_sat() {
     let four = manager.mk_int(4);
     let eq = manager.mk_eq(square, four);
 
-    let result = dispatch_nia_constraints(&[eq], &manager, true);
+    let result = dispatch_nia_constraints(&[eq], &mut manager, true);
     assert!(matches!(result, Some(NlDispatchResult::Sat(_))), "x*x=4 with x:Int is SAT (x=±2)");
 }
 
@@ -130,7 +130,7 @@ fn test_nia_dropped_disjunction_does_not_fabricate_sat() {
     let y_eq_100 = manager.mk_eq(y, hundred);
     let disj = manager.mk_or(vec![x_eq_100, y_eq_100]);
 
-    let result = dispatch_nia_constraints(&[eq_prod, disj], &manager, true);
+    let result = dispatch_nia_constraints(&[eq_prod, disj], &mut manager, true);
 
     assert!(!matches!(result, Some(NlDispatchResult::Sat(_))), "a dropped disjunction must not let the relaxed x*y=12 be certified SAT");
 }
@@ -181,7 +181,7 @@ fn test_nia_untranslatable_operand_does_not_fabricate_sat() {
     let three = manager.mk_int(3);
     let eq_div = manager.mk_eq(div_xy, three);
 
-    let result = dispatch_nia_constraints(&[eq_sq, eq_div], &manager, true);
+    let result = dispatch_nia_constraints(&[eq_sq, eq_div], &mut manager, true);
 
     assert!(!matches!(result, Some(NlDispatchResult::Sat(_))), "an untranslatable div atom must not be dropped into a false SAT");
 }


### PR DESCRIPTION
## Summary
- Close QF_NIA completeness gaps (define-fun, bounded integer enum, multivariate)
- Grammar-driven arithmetic purification; sound QF_ANIA path
- CE suites + z3_parity QF_NIA
- **get-model** after NL sat; **ALL** auto-detect NIA/NRA/ANIA
- **Soundness fix:** QF_NIA spurious `sat` on `let`/`ite` nonlinear formulas
  - `term_is_nonlinear` ignored `Let`/`Ite` → NIA never ran; CDCL missed products under ite
  - Detect nonlinearity under let/ite; walk ite in honesty gate; Bool case-split + ite expansion; fold constant ite
  - Repro / `calypto/problem-000044.cvc.2.smt2`: no longer `sat` (honest `unknown` until B&B closes remaining branches)

## Test plan
- [x] `cargo test -p oxiz-solver --test qf_nia_ce --test qf_ania_ce`
- [x] `cargo test -p oxiz-solver --test qf_nia_soundness`
- [x] `cargo test -p oxiz-theories --test nlsat_mixed_sort`
- [x] Manual calypto-style formula → not sat