### PR TITLE
fix(qf-bv): unsat for strict comparisons against domain bounds

### DIFF
--- a/oxiz-solver/src/solver/encode.rs
+++ b/oxiz-solver/src/solver/encode.rs
@@ -31,6 +31,23 @@ impl Solver {
         var
     }
 
+    /// Pin a BV variable's dual ArithSolver image to the unsigned domain
+    /// `[0, 2^w − 1]`.  Widths above 63 skip the upper bound (doesn't fit
+    /// `i64`); the lower bound `x ≥ 0` is always asserted.
+    fn ensure_bv_arith_domain(&mut self, term: TermId, width: u32) {
+        // Reason term is the BV var itself — these are structural domain axioms,
+        // not user assertions; cores that surface them are still sound supersets.
+        let reason = term;
+        let one = [(term, Rational64::one())];
+        self.arith
+            .assert_ge(&one, Rational64::zero(), reason);
+        if width > 0 && width <= 63 {
+            let max = (1i64 << width) - 1;
+            self.arith
+                .assert_le(&one, Rational64::from_integer(max), reason);
+        }
+    }
+
     /// Track theory variables in a term for model extraction.
     /// Recursively scans a term to find Int/Real/BV variables and registers them.
     ///
@@ -62,10 +79,15 @@ impl Solver {
                     self.trail.push(TrailOp::BvTermAdded { term: term_id });
                     if let Some(width) = sort.bitvec_width() {
                         self.bv.new_bv(term_id, width);
+                        // Also intern in ArithSolver for BV comparison constraints
+                        // (BV comparisons are handled as bounded integer arithmetic)
+                        self.arith.intern(term_id);
+                        // Unsigned domain 0 ≤ x ≤ 2^w−1 so dual arith encoding of
+                        // `(bvult x #b0)` is unsat rather than sat at x = −1.
+                        self.ensure_bv_arith_domain(term_id, width);
+                    } else {
+                        self.arith.intern(term_id);
                     }
-                    // Also intern in ArithSolver for BV comparison constraints
-                    // (BV comparisons are handled as bounded integer arithmetic)
-                    self.arith.intern(term_id);
                 }
             }
             // Recursively scan compound terms.

--- a/oxiz-solver/src/solver/model_builder.rs
+++ b/oxiz-solver/src/solver/model_builder.rs
@@ -2,12 +2,29 @@
 
 #[allow(unused_imports)]
 use crate::prelude::*;
-use num_traits::ToPrimitive;
+use num_bigint::BigInt;
+use num_traits::{Signed, ToPrimitive, Zero};
 use oxiz_core::ast::{TermId, TermKind, TermManager};
 
 use super::Solver;
 use super::types::Constraint;
 use super::types::{Model, UnsatCore};
+
+/// Reduce an integer to the canonical unsigned representative in `[0, 2^w)`.
+///
+/// Defends model output against a stale arith assignment outside the BV domain
+/// (historically `x = -1` → malformed `#x-1`).
+fn bv_model_u_bits(value: impl Into<BigInt>, width: u32) -> BigInt {
+    if width == 0 {
+        return BigInt::zero();
+    }
+    let modulus = BigInt::from(1) << width as usize;
+    let mut v = value.into() % &modulus;
+    if v.is_negative() {
+        v += &modulus;
+    }
+    v
+}
 
 impl Solver {
     pub(super) fn build_model(&mut self, manager: &mut TermManager) {
@@ -180,7 +197,7 @@ impl Solver {
                 if let Some(bv_value) = bv_value {
                     manager.mk_bitvec(bv_value, width)
                 } else if let Some(arith_value) = arith_value {
-                    manager.mk_bitvec(arith_value.to_integer(), width)
+                    manager.mk_bitvec(bv_model_u_bits(arith_value.to_integer(), width), width)
                 } else {
                     manager.mk_bitvec(0i64, width)
                 }
@@ -189,7 +206,7 @@ impl Solver {
                 // bounds, so prefer its value; only fall back to the (unpinned)
                 // BV bits or a default when arith has nothing.
                 if let Some(arith_value) = arith_value {
-                    manager.mk_bitvec(arith_value.to_integer(), width)
+                    manager.mk_bitvec(bv_model_u_bits(arith_value.to_integer(), width), width)
                 } else if let Some(bv_value) = bv_value {
                     manager.mk_bitvec(bv_value, width)
                 } else {

--- a/oxiz-solver/src/solver/theory_manager.rs
+++ b/oxiz-solver/src/solver/theory_manager.rs
@@ -1100,17 +1100,18 @@ impl<'a> TheoryManager<'a> {
                 self.intern_term_for_congruence(lhs, manager);
                 self.intern_term_for_congruence(rhs, manager);
 
-                // Check if this is a BV comparison
-                let lhs_is_bv = self.bv_terms.contains(&lhs);
-                let rhs_is_bv = self.bv_terms.contains(&rhs);
+                // BV comparisons by *sort*, not `bv_terms` membership.
+                // `bv_terms` only tracks free BV *variables*; compound operands
+                // like `(bvadd x y)` are absent, so gating on `bv_terms` skipped
+                // the BV path entirely and left `(bvslt (bvadd x y) smin)` as a
+                // free Boolean → spurious sat (issue #17 follow-up).
+                let lhs_is_bv = self.bv_width_of(lhs, manager).is_some();
+                let rhs_is_bv = self.bv_width_of(rhs, manager).is_some();
 
                 // Handle BV comparisons
                 if lhs_is_bv || rhs_is_bv {
-                    // Bit-blast both operands *with constants pinned*.  Bare
-                    // `new_bv` leaves `BitVecConst` bits unconstrained, so
-                    // `(bvult x #b0)` was treated as `x < free` and reported
-                    // sat (issue #17).  `bit_blast_bv_pair` routes through
-                    // `encode_bv_term_recursive`, which calls `assert_const`.
+                    // Bit-blast both operands *with constants pinned* and
+                    // compounds fully encoded via `encode_bv_term_recursive`.
                     if self.bit_blast_bv_pair(lhs, rhs, manager) {
                         // Derive signedness from the original TermKind stored for
                         // the SAT variable.  Both BvSlt and BvUlt encode to

--- a/oxiz-solver/src/solver/theory_manager.rs
+++ b/oxiz-solver/src/solver/theory_manager.rs
@@ -1106,16 +1106,12 @@ impl<'a> TheoryManager<'a> {
 
                 // Handle BV comparisons
                 if lhs_is_bv || rhs_is_bv {
-                    // Get BV width
-                    let width = manager
-                        .get(lhs)
-                        .and_then(|t| manager.sorts.get(t.sort).and_then(|s| s.bitvec_width()));
-
-                    if let Some(width) = width {
-                        // Ensure both operands have BV variables
-                        self.bv.new_bv(lhs, width);
-                        self.bv.new_bv(rhs, width);
-
+                    // Bit-blast both operands *with constants pinned*.  Bare
+                    // `new_bv` leaves `BitVecConst` bits unconstrained, so
+                    // `(bvult x #b0)` was treated as `x < free` and reported
+                    // sat (issue #17).  `bit_blast_bv_pair` routes through
+                    // `encode_bv_term_recursive`, which calls `assert_const`.
+                    if self.bit_blast_bv_pair(lhs, rhs, manager) {
                         // Derive signedness from the original TermKind stored for
                         // the SAT variable.  Both BvSlt and BvUlt encode to
                         // Constraint::Lt(lhs, rhs) during formula encoding (encode.rs),

--- a/oxiz-solver/tests/qf_bv_strict_bounds.rs
+++ b/oxiz-solver/tests/qf_bv_strict_bounds.rs
@@ -108,3 +108,46 @@ fn bvult_x_zero_widths() {
         assert_eq!(r, SolverResult::Unsat, "width={w} outputs={out:?}");
     }
 }
+
+/// Issue #17 follow-up: compound LHS must also hit the BV path.
+#[test]
+fn bvslt_bvadd_smin_is_unsat() {
+    let (r, out) = run(
+        r#"
+        (set-logic QF_BV)
+        (declare-const x1 (_ BitVec 8))
+        (declare-const x3 (_ BitVec 8))
+        (assert (bvslt (bvadd x1 x3) #b10000000))
+        (check-sat)
+        "#,
+    );
+    assert_eq!(r, SolverResult::Unsat, "outputs={out:?}");
+}
+
+#[test]
+fn bvslt_bvand_bvudiv_smin_is_unsat() {
+    let (r, out) = run(
+        r#"
+        (set-logic QF_BV)
+        (declare-const x1 (_ BitVec 8))
+        (declare-const x3 (_ BitVec 8))
+        (assert (bvslt (bvand (bvudiv x1 #b11110110) x3) #b10000000))
+        (check-sat)
+        "#,
+    );
+    assert_eq!(r, SolverResult::Unsat, "outputs={out:?}");
+}
+
+#[test]
+fn bvult_bvadd_zero_is_unsat() {
+    let (r, out) = run(
+        r#"
+        (set-logic QF_BV)
+        (declare-const x (_ BitVec 8))
+        (declare-const y (_ BitVec 8))
+        (assert (bvult (bvadd x y) #b00000000))
+        (check-sat)
+        "#,
+    );
+    assert_eq!(r, SolverResult::Unsat, "outputs={out:?}");
+}

--- a/oxiz-solver/tests/qf_bv_strict_bounds.rs
+++ b/oxiz-solver/tests/qf_bv_strict_bounds.rs
@@ -1,0 +1,110 @@
+//! Issue #17: trivially-unsatisfiable strict BV comparisons must be unsat,
+//! not sat with a malformed model (`#x-1`).
+
+use oxiz_solver::{Context, SolverResult};
+
+fn run(script: &str) -> (SolverResult, Vec<String>) {
+    let mut ctx = Context::new();
+    let outputs = ctx.execute_script(script).expect("script");
+    let result = outputs
+        .iter()
+        .rev()
+        .find_map(|l| match l.trim() {
+            "sat" => Some(SolverResult::Sat),
+            "unsat" => Some(SolverResult::Unsat),
+            "unknown" => Some(SolverResult::Unknown),
+            _ => None,
+        })
+        .unwrap_or(SolverResult::Unknown);
+    (result, outputs)
+}
+
+#[test]
+fn bvult_x_zero_is_unsat() {
+    let (r, out) = run(
+        r#"
+        (set-logic QF_BV)
+        (declare-const x (_ BitVec 8))
+        (assert (bvult x #b00000000))
+        (check-sat)
+        "#,
+    );
+    assert_eq!(r, SolverResult::Unsat, "outputs={out:?}");
+}
+
+#[test]
+fn bvslt_x_smin_is_unsat() {
+    // signed min for 8-bit is #b10000000 = -128; nothing is strictly less
+    let (r, out) = run(
+        r#"
+        (set-logic QF_BV)
+        (declare-const x (_ BitVec 8))
+        (assert (bvslt x #b10000000))
+        (check-sat)
+        "#,
+    );
+    assert_eq!(r, SolverResult::Unsat, "outputs={out:?}");
+}
+
+#[test]
+fn bvsgt_smin_x_is_unsat() {
+    // −128 > x is unsat for all x
+    let (r, out) = run(
+        r#"
+        (set-logic QF_BV)
+        (declare-const x (_ BitVec 8))
+        (assert (bvsgt #b10000000 x))
+        (check-sat)
+        "#,
+    );
+    assert_eq!(r, SolverResult::Unsat, "outputs={out:?}");
+}
+
+#[test]
+fn bvule_x_zero_is_sat_at_zero() {
+    let (r, out) = run(
+        r#"
+        (set-logic QF_BV)
+        (declare-const x (_ BitVec 8))
+        (assert (bvule x #b00000000))
+        (check-sat)
+        (get-value (x))
+        "#,
+    );
+    assert_eq!(r, SolverResult::Sat, "outputs={out:?}");
+    let joined = out.join("\n");
+    assert!(
+        !joined.contains("#x-1") && !joined.contains("-1"),
+        "model must not contain malformed negative BV literal: {joined}"
+    );
+}
+
+#[test]
+fn bvsle_x_smin_is_sat() {
+    let (r, out) = run(
+        r#"
+        (set-logic QF_BV)
+        (declare-const x (_ BitVec 8))
+        (assert (bvsle x #b10000000))
+        (check-sat)
+        "#,
+    );
+    assert_eq!(r, SolverResult::Sat, "outputs={out:?}");
+}
+
+#[test]
+fn bvult_x_zero_widths() {
+    for w in [4u32, 8, 16, 32] {
+        let zeros = "0".repeat(w as usize);
+        let script = format!(
+            r#"
+            (set-logic QF_BV)
+            (declare-const x (_ BitVec {w}))
+            (assert (bvult x #b{zeros}))
+            (check-sat)
+            "#
+        );
+        let (r, out) = run(&script);
+        assert_eq!(r, SolverResult::Unsat, "width={w} outputs={out:?}");
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes spurious `sat` + malformed model `#x-1` for trivially unsatisfiable strict BV comparisons (e.g. `(bvult x #b0)`, `(bvslt x smin)`).
- Root cause (bare var): BV comparison path used bare `new_bv` so `BitVecConst` bits were unconstrained; dual ArithSolver path treated BV vars as unbounded Ints.
- Fix: bit-blast comparison operands via `bit_blast_bv_pair` (pins constants); pin arith domain to `[0, 2^w−1]`; clamp model BV values to unsigned range.
- **Follow-up:** compound LHS (`(bvslt (bvadd x y) smin)`) still sat because comparisons gated on `bv_terms` (vars only). Now detect BV by **operand sort** and fully bit-blast compounds.

Closes #17

## Test plan
- [x] `cargo test -p oxiz-solver --test qf_bv_strict_bounds`
- [x] Manual: bare var + compound LHS cases → unsat