### PR TITLE
fix(qf-s): unsat for conflicting string eqs; install string models

### DIFF
--- a/oxiz-solver/src/context/model_fmt.rs
+++ b/oxiz-solver/src/context/model_fmt.rs
@@ -344,6 +344,7 @@ impl Context {
             return "?".to_string();
         };
         match &s.kind {
+            SortKind::String => "\"\"".to_string(),
             SortKind::BitVec(w) => format!("#b{:0>width$}", "0", width = *w as usize),
             // Positive zero is a canonical, valid ground FP value.
             SortKind::FloatingPoint { eb, sb } => format!("(_ +zero {eb} {sb})"),

--- a/oxiz-solver/src/solver/check_string.rs
+++ b/oxiz-solver/src/solver/check_string.rs
@@ -18,14 +18,16 @@ impl Solver {
 
         // First pass: collect all string assignments and constraints from assertions
         for &assertion in &self.assertions {
-            self.collect_string_constraints(
+            if self.collect_string_constraints(
                 assertion,
                 manager,
                 &mut string_assignments,
                 &mut length_constraints,
                 &mut concat_equalities,
                 &mut replace_all_constraints,
-            );
+            ) {
+                return true; // conflicting constant assignments
+            }
         }
 
         // Second pass: Now that all variable assignments are collected, resolve replace_all constraints
@@ -40,36 +42,93 @@ impl Solver {
         }
 
         // Check 1: Length vs concrete string conflicts (string_04 fix)
-        // If we have len(x) = n and x = "literal", check if len("literal") == n
         for (&var, &declared_len) in &length_constraints {
             if let Some(value) = string_assignments.get(&var) {
                 let actual_len = value.chars().count() as i64;
                 if actual_len != declared_len {
-                    return true; // Conflict: declared length != actual length
+                    return true;
                 }
             }
         }
 
-        // Check 2: Concatenation length consistency (string_02 fix)
-        // If we have concat(a, b, c) = "result", check if sum of lengths is consistent
+        // Check 2: Concatenation consistency against a concrete result.
         for (operands, result_str) in &concat_equalities {
             let result_len = result_str.chars().count() as i64;
-            let mut total_declared_len = 0i64;
-            let mut all_have_length = true;
+            let mut total_known_len = 0i64;
+            let mut all_known = true;
+            let mut known_prefix = String::new();
+            let mut prefix_broken = false;
+            let mut known_suffix_parts: Vec<String> = Vec::new();
 
             for operand in operands {
-                if let Some(&len) = length_constraints.get(operand) {
-                    total_declared_len += len;
-                } else if let Some(value) = string_assignments.get(operand) {
-                    total_declared_len += value.chars().count() as i64;
+                let concrete = string_assignments
+                    .get(operand)
+                    .cloned()
+                    .or_else(|| self.get_string_literal(*operand, manager));
+                if let Some(value) = concrete {
+                    total_known_len += value.chars().count() as i64;
+                    if !prefix_broken {
+                        known_prefix.push_str(&value);
+                    } else {
+                        known_suffix_parts.push(value);
+                    }
+                } else if let Some(&len) = length_constraints.get(operand) {
+                    total_known_len += len;
+                    prefix_broken = true;
+                    all_known = false;
                 } else {
-                    all_have_length = false;
-                    break;
+                    prefix_broken = true;
+                    all_known = false;
                 }
             }
 
-            if all_have_length && total_declared_len != result_len {
-                return true; // Conflict: sum of operand lengths != result length
+            if all_known {
+                let mut cat = String::new();
+                for op in operands {
+                    if let Some(v) = string_assignments.get(op) {
+                        cat.push_str(v);
+                    } else if let Some(lit) = self.get_string_literal(*op, manager) {
+                        cat.push_str(&lit);
+                    }
+                }
+                if cat != *result_str {
+                    return true;
+                }
+            } else {
+                // Leading concrete operands must form a prefix of the result
+                // (e.g. "a" ++ s = "bcd" is unsat).
+                if !known_prefix.is_empty() && !result_str.starts_with(&known_prefix) {
+                    return true;
+                }
+                // Trailing concrete operands (after the first unknown) must form
+                // a suffix when they are contiguous at the end.
+                if !known_suffix_parts.is_empty() {
+                    // Only treat as a firm suffix if the last operand(s) after the
+                    // first unknown are all concrete with no further unknowns —
+                    // already true by construction of known_suffix_parts only
+                    // collecting after prefix_broken, but unknowns in the middle
+                    // leave trailing parts that must still match if the trailing
+                    // run reaches the end.  Rebuild trailing run from the end.
+                    let mut trailing = String::new();
+                    for op in operands.iter().rev() {
+                        let concrete = string_assignments
+                            .get(op)
+                            .cloned()
+                            .or_else(|| self.get_string_literal(*op, manager));
+                        if let Some(v) = concrete {
+                            trailing = format!("{v}{trailing}");
+                        } else {
+                            break;
+                        }
+                    }
+                    if !trailing.is_empty() && !result_str.ends_with(&trailing) {
+                        return true;
+                    }
+                }
+                // Lower bound: sum of known pieces cannot exceed result length.
+                if total_known_len > result_len {
+                    return true;
+                }
             }
         }
 
@@ -110,7 +169,9 @@ impl Solver {
         false // No conflict found
     }
 
-    /// Recursively collect string constraints from a term
+    /// Recursively collect string constraints from a term.
+    /// Returns `true` if a definite conflict is found during collection
+    /// (e.g. the same variable equated to two different string literals).
     fn collect_string_constraints(
         &self,
         term: TermId,
@@ -119,24 +180,35 @@ impl Solver {
         length_constraints: &mut FxHashMap<TermId, i64>,
         concat_equalities: &mut Vec<(Vec<TermId>, String)>,
         replace_all_constraints: &mut Vec<(TermId, TermId, String, String, String)>,
-    ) {
+    ) -> bool {
         let Some(term_data) = manager.get(term) else {
-            return;
+            return false;
         };
 
         match &term_data.kind {
             // Handle equality: look for string-related equalities
             TermKind::Eq(lhs, rhs) => {
-                // Check for variable = string literal
+                // Variable = string literal (conflict if already assigned
+                // a different value — issue #14).
                 if let Some(lit) = self.get_string_literal(*rhs, manager) {
-                    // lhs = "literal"
                     if self.is_string_variable(*lhs, manager) {
-                        string_assignments.insert(*lhs, lit);
+                        if let Some(prev) = string_assignments.get(lhs) {
+                            if prev != &lit {
+                                return true;
+                            }
+                        } else {
+                            string_assignments.insert(*lhs, lit);
+                        }
                     }
                 } else if let Some(lit) = self.get_string_literal(*lhs, manager) {
-                    // "literal" = rhs
                     if self.is_string_variable(*rhs, manager) {
-                        string_assignments.insert(*rhs, lit);
+                        if let Some(prev) = string_assignments.get(rhs) {
+                            if prev != &lit {
+                                return true;
+                            }
+                        } else {
+                            string_assignments.insert(*rhs, lit);
+                        }
                     }
                 }
 
@@ -207,84 +279,93 @@ impl Solver {
                 }
 
                 // Recursively check children
-                self.collect_string_constraints(
+                if self.collect_string_constraints(
                     *lhs,
                     manager,
                     string_assignments,
                     length_constraints,
                     concat_equalities,
                     replace_all_constraints,
-                );
-                self.collect_string_constraints(
+                ) || self.collect_string_constraints(
                     *rhs,
                     manager,
                     string_assignments,
                     length_constraints,
                     concat_equalities,
                     replace_all_constraints,
-                );
+                ) {
+                    return true;
+                }
             }
 
             // Handle And: recurse into all conjuncts
             TermKind::And(args) => {
                 for &arg in args {
-                    self.collect_string_constraints(
+                    if self.collect_string_constraints(
                         arg,
                         manager,
                         string_assignments,
                         length_constraints,
                         concat_equalities,
                         replace_all_constraints,
-                    );
+                    ) {
+                        return true;
+                    }
                 }
             }
 
             // Handle other compound terms
             TermKind::Or(args) => {
                 for &arg in args {
-                    self.collect_string_constraints(
+                    if self.collect_string_constraints(
                         arg,
                         manager,
                         string_assignments,
                         length_constraints,
                         concat_equalities,
                         replace_all_constraints,
-                    );
+                    ) {
+                        return true;
+                    }
                 }
             }
 
             TermKind::Not(inner) => {
-                self.collect_string_constraints(
+                if self.collect_string_constraints(
                     *inner,
                     manager,
                     string_assignments,
                     length_constraints,
                     concat_equalities,
                     replace_all_constraints,
-                );
+                ) {
+                    return true;
+                }
             }
 
             TermKind::Implies(lhs, rhs) => {
-                self.collect_string_constraints(
+                if self.collect_string_constraints(
                     *lhs,
                     manager,
                     string_assignments,
                     length_constraints,
                     concat_equalities,
                     replace_all_constraints,
-                );
-                self.collect_string_constraints(
+                ) || self.collect_string_constraints(
                     *rhs,
                     manager,
                     string_assignments,
                     length_constraints,
                     concat_equalities,
                     replace_all_constraints,
-                );
+                ) {
+                    return true;
+                }
             }
 
             _ => {}
         }
+        false
     }
 
     /// Get string literal value from a term
@@ -514,13 +595,22 @@ impl Solver {
     ///
     /// Returns `true` only when a concrete assignment to every string variable
     /// makes the whole assertion set evaluate to `true` — a sound `Sat`
-    /// certificate. When no such witness is found within the search bounds it
-    /// returns `false`, and the caller keeps the honest `Unknown` verdict.
-    pub(super) fn ground_string_model_sat(&self, manager: &TermManager) -> bool {
-        matches!(
-            solve_ground_string(manager, &self.assertions),
-            GroundStringOutcome::Sat
-        )
+    /// certificate. On success the witness is installed into `self.model` so
+    /// `(get-model)` / `(get-value …)` work (issue #14). When no such witness
+    /// is found it returns `false`, and the caller keeps the honest `Unknown`.
+    pub(super) fn ground_string_model_sat(&mut self, manager: &mut TermManager) -> bool {
+        match solve_ground_string(manager, &self.assertions) {
+            GroundStringOutcome::Sat(assignment) => {
+                let mut model = super::types::Model::new();
+                for (term, value) in assignment {
+                    let lit = manager.mk_string_lit(&value);
+                    model.set(term, lit);
+                }
+                self.model = Some(model);
+                true
+            }
+            GroundStringOutcome::Unknown => false,
+        }
     }
 
     /// Returns `true` when the current assertion set contains any string-theory

--- a/oxiz-solver/src/solver/model_builder.rs
+++ b/oxiz-solver/src/solver/model_builder.rs
@@ -52,14 +52,28 @@ impl Solver {
                 let rhs_is_apply = manager
                     .get(*rhs)
                     .is_some_and(|t| matches!(t.kind, TermKind::Apply { .. }));
+                let is_str_var = |tid: TermId| -> bool {
+                    manager.get(tid).is_some_and(|t| {
+                        matches!(t.kind, TermKind::Var(_))
+                            && manager
+                                .sorts
+                                .get(t.sort)
+                                .is_some_and(|s| matches!(s.kind, oxiz_core::sort::SortKind::String))
+                    })
+                };
+                let lhs_is_str_var = is_str_var(*lhs);
+                let rhs_is_str_var = is_str_var(*rhs);
+
                 let (var_term, const_term) = if self.arith_terms.contains(lhs)
                     || self.bv_terms.contains(lhs)
                     || lhs_is_apply
+                    || lhs_is_str_var
                 {
                     (*lhs, *rhs)
                 } else if self.arith_terms.contains(rhs)
                     || self.bv_terms.contains(rhs)
                     || rhs_is_apply
+                    || rhs_is_str_var
                 {
                     (*rhs, *lhs)
                 } else {
@@ -87,6 +101,11 @@ impl Solver {
                             let value_term = manager.mk_bitvec(val, *width);
                             model.set(var_term, value_term);
                         }
+                    }
+                    TermKind::StringLit(s) => {
+                        let s = s.clone();
+                        let value_term = manager.mk_string_lit(&s);
+                        model.set(var_term, value_term);
                     }
                     _ => {}
                 }

--- a/oxiz-solver/src/solver/theory_manager.rs
+++ b/oxiz-solver/src/solver/theory_manager.rs
@@ -107,6 +107,10 @@ pub(crate) struct TheoryManager<'a> {
     /// between same-width constants, bounding the edge count by the number of
     /// distinct BV literals in the formula.
     interned_bv_constants: FxHashMap<(u64, u32), u32>,
+    /// Canonical EUF nodes for distinct string literals.  EUF has no built-in
+    /// notion that `"x" ≠ "y"`, so without explicit diseqs `s="x" ∧ s="y"` is
+    /// spuriously sat (issue #14).
+    interned_string_constants: FxHashMap<String, u32>,
     /// Canonical EUF nodes for Boolean true and false values.
     /// Used to track Bool-valued function applications in EUF:
     /// when `f(x)` is assigned true by the SAT solver, we merge its EUF node
@@ -203,6 +207,7 @@ impl<'a> TheoryManager<'a> {
             has_bv_arith_ops,
             interned_int_constants: FxHashMap::default(),
             interned_bv_constants: FxHashMap::default(),
+            interned_string_constants: FxHashMap::default(),
             bool_true_node: None,
             bool_false_node: None,
             resource_exhausted: false,
@@ -267,6 +272,7 @@ impl<'a> TheoryManager<'a> {
         self.bv.reset();
         self.interned_int_constants.clear();
         self.interned_bv_constants.clear();
+        self.interned_string_constants.clear();
         self.bool_true_node = None;
         self.bool_false_node = None;
         self.processed_equalities.clear();
@@ -632,6 +638,22 @@ impl<'a> TheoryManager<'a> {
                         self.euf.assert_diseq(new_node, other_node, term);
                     }
                     self.interned_bv_constants.insert(key, new_node);
+                    return new_node;
+                }
+                TermKind::StringLit(s) => {
+                    // Pairwise diseqs between distinct string literals so
+                    // `s = "x" ∧ s = "y"` is unsat in EUF (issue #14).
+                    let new_node = self.euf.intern(term);
+                    if let Some(&canonical) = self.interned_string_constants.get(s) {
+                        let _ = self.euf.merge(new_node, canonical, term);
+                        return canonical;
+                    }
+                    let diseq_targets: Vec<u32> =
+                        self.interned_string_constants.values().copied().collect();
+                    for other_node in diseq_targets {
+                        self.euf.assert_diseq(new_node, other_node, term);
+                    }
+                    self.interned_string_constants.insert(s.clone(), new_node);
                     return new_node;
                 }
                 _ => {}
@@ -1586,6 +1608,8 @@ impl TheoryCallback for TheoryManager<'_> {
 
         // Evict stale bit-vector-constant canonicals for the same reason.
         self.interned_bv_constants
+            .retain(|_key, &mut canonical| (canonical as usize) < live_nodes);
+        self.interned_string_constants
             .retain(|_key, &mut canonical| (canonical as usize) < live_nodes);
 
         // Evict stale Boolean canonical nodes

--- a/oxiz-solver/src/solver/types.rs
+++ b/oxiz-solver/src/solver/types.rs
@@ -532,7 +532,8 @@ impl Model {
             | TermKind::False
             | TermKind::IntConst(_)
             | TermKind::RealConst(_)
-            | TermKind::BitVecConst { .. } => term,
+            | TermKind::BitVecConst { .. }
+            | TermKind::StringLit(_) => term,
 
             // Variables: look up in model or return the variable itself
             TermKind::Var(_) => self.get(term).unwrap_or(term),

--- a/oxiz-solver/tests/qf_s_issue14.rs
+++ b/oxiz-solver/tests/qf_s_issue14.rs
@@ -1,0 +1,95 @@
+//! Issue #14: QF_S conflicting string equalities must be unsat; models must
+//! carry concrete string values.
+
+use oxiz_solver::{Context, SolverResult};
+
+fn run(script: &str) -> (SolverResult, Vec<String>) {
+    let mut ctx = Context::new();
+    let outputs = ctx.execute_script(script).expect("script");
+    let result = outputs
+        .iter()
+        .rev()
+        .find_map(|l| match l.trim() {
+            "sat" => Some(SolverResult::Sat),
+            "unsat" => Some(SolverResult::Unsat),
+            "unknown" => Some(SolverResult::Unknown),
+            _ => None,
+        })
+        .unwrap_or(SolverResult::Unknown);
+    (result, outputs)
+}
+
+#[test]
+fn conflicting_string_eq_is_unsat() {
+    let (r, out) = run(
+        r#"
+        (set-logic QF_S)
+        (declare-const s String)
+        (assert (= s "x"))
+        (assert (= s "y"))
+        (check-sat)
+        "#,
+    );
+    assert_eq!(r, SolverResult::Unsat, "outputs={out:?}");
+}
+
+#[test]
+fn concat_prefix_mismatch_is_unsat() {
+    let (r, out) = run(
+        r#"
+        (set-logic QF_S)
+        (declare-const s String)
+        (assert (= (str.++ "a" s) "bcd"))
+        (check-sat)
+        "#,
+    );
+    assert_eq!(r, SolverResult::Unsat, "outputs={out:?}");
+}
+
+#[test]
+fn string_eq_get_value_and_model() {
+    let (r, out) = run(
+        r#"
+        (set-logic QF_S)
+        (declare-const s String)
+        (assert (= s "353"))
+        (check-sat)
+        (get-value (s))
+        (get-model)
+        "#,
+    );
+    assert_eq!(r, SolverResult::Sat, "outputs={out:?}");
+    let joined = out.join("\n");
+    assert!(
+        joined.contains("\"353\""),
+        "model/value must contain string 353, got: {joined}"
+    );
+    assert!(
+        !joined.contains("((s s))"),
+        "get-value must not echo the variable: {joined}"
+    );
+    assert!(
+        !joined.contains("Bool"),
+        "string const must not get Bool sort: {joined}"
+    );
+}
+
+#[test]
+fn concat_solve_get_value() {
+    let (r, out) = run(
+        r#"
+        (set-logic QF_S)
+        (declare-const s String)
+        (assert (= (str.++ "* " s) "* 353"))
+        (check-sat)
+        (get-value (s))
+        (get-model)
+        "#,
+    );
+    assert_eq!(r, SolverResult::Sat, "outputs={out:?}");
+    let joined = out.join("\n");
+    assert!(
+        joined.contains("\"353\""),
+        "s must be 353, got: {joined}"
+    );
+}

--- a/oxiz-theories/src/string/ground_solver.rs
+++ b/oxiz-theories/src/string/ground_solver.rs
@@ -42,10 +42,11 @@ use oxiz_core::ast::{TermId, TermKind, TermManager};
 /// formulas is handled by the definite-conflict detectors in `oxiz-solver`.
 /// This procedure only ever *confirms* satisfiability with a concrete witness
 /// (`Sat`) or gives up (`Unknown`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GroundStringOutcome {
     /// A concrete model was constructed and verified against every assertion.
-    Sat,
+    /// The map assigns every free string variable a concrete value.
+    Sat(FxHashMap<TermId, String>),
     /// No verified model could be built within the search bounds.
     Unknown,
 }
@@ -67,7 +68,7 @@ pub fn solve_ground_string(manager: &TermManager, assertions: &[TermId]) -> Grou
     let mut builder = ModelBuilder::new(manager, assertions);
     builder.gather();
     if builder.build_assignment() && builder.verify() {
-        return GroundStringOutcome::Sat;
+        return GroundStringOutcome::Sat(builder.model);
     }
     GroundStringOutcome::Unknown
 }
@@ -1026,7 +1027,7 @@ mod tests {
                (assert (= x "hel"))
                (assert (= y "lo"))"#,
         );
-        assert_eq!(out, GroundStringOutcome::Sat);
+        assert!(matches!(out, GroundStringOutcome::Sat(_)));
     }
 
     #[test]
@@ -1038,7 +1039,7 @@ mod tests {
                (assert (= (str.len t) 3))
                (assert (= (str.++ s t) "worldfoo"))"#,
         );
-        assert_eq!(out, GroundStringOutcome::Sat);
+        assert!(matches!(out, GroundStringOutcome::Sat(_)));
     }
 
     #[test]
@@ -1049,7 +1050,7 @@ mod tests {
                (assert (str.prefixof "my" s))
                (assert (>= (str.len s) 6))"#,
         );
-        assert_eq!(out, GroundStringOutcome::Sat);
+        assert!(matches!(out, GroundStringOutcome::Sat(_)));
     }
 
     #[test]
@@ -1060,7 +1061,7 @@ mod tests {
                (assert (str.contains text "file"))
                (assert (<= (str.len text) 15))"#,
         );
-        assert_eq!(out, GroundStringOutcome::Sat);
+        assert!(matches!(out, GroundStringOutcome::Sat(_)));
     }
 
     #[test]
@@ -1072,7 +1073,7 @@ mod tests {
                (assert (= input "the old way"))
                (assert (= output "the new way"))"#,
         );
-        assert_eq!(out, GroundStringOutcome::Sat);
+        assert!(matches!(out, GroundStringOutcome::Sat(_)));
     }
 
     #[test]
@@ -1083,7 +1084,7 @@ mod tests {
                (assert (= (str.len phone) 10))
                (assert (str.prefixof "call" phone))"#,
         );
-        assert_eq!(out, GroundStringOutcome::Sat);
+        assert!(matches!(out, GroundStringOutcome::Sat(_)));
     }
 
     #[test]
@@ -1095,7 +1096,7 @@ mod tests {
                (assert (<= (str.len word) 8))
                (assert (str.contains word "test"))"#,
         );
-        assert_eq!(out, GroundStringOutcome::Sat);
+        assert!(matches!(out, GroundStringOutcome::Sat(_)));
     }
 
     #[test]
@@ -1118,7 +1119,7 @@ mod tests {
                (assert (= r (str.replace "abc" "" "X")))
                (assert (= r "Xabc"))"#,
         );
-        assert_eq!(out, GroundStringOutcome::Sat);
+        assert!(matches!(out, GroundStringOutcome::Sat(_)));
         // The wrong reading (unchanged) must NOT verify.
         let bad = solve(
             r#"(declare-const r String)
@@ -1132,7 +1133,7 @@ mod tests {
                (assert (= r (str.replace_all "abc" "" "X")))
                (assert (= r "abc"))"#,
         );
-        assert_eq!(all, GroundStringOutcome::Sat);
+        assert!(matches!(all, GroundStringOutcome::Sat(_)));
     }
 
     #[test]
@@ -1156,6 +1157,6 @@ mod tests {
                (assert (not (str.in_re w (str.to_re "cat"))))
                (assert (str.in_re w (re.++ (re.range "a" "z") (re.++ (re.range "a" "z") (re.range "a" "z")))))"#,
         );
-        assert_eq!(out, GroundStringOutcome::Sat);
+        assert!(matches!(out, GroundStringOutcome::Sat(_)));
     }
 }


### PR DESCRIPTION
## Summary
- Fixes issue #14: `s="x" ∧ s="y"` reported `sat`; string models missing / wrong.
- EUF: pairwise diseqs between distinct string literals (same pattern as Int/BV constants).
- Early string conflict detectors: double assignment + concat prefix/suffix mismatch (`"a"++s = "bcd"`).
- Ground string solver returns the witness map; install into `self.model` on sat.
- `build_model` extracts `Var = StringLit` equalities; `Model::eval` treats `StringLit` as constant; default String value is `""`.

Closes #14

## Test plan
- [x] `cargo test -p oxiz-solver --test qf_s_issue14`
- [x] `cargo test -p oxiz-solver --test qf_s_ground_string`
- [x] `cargo test -p oxiz-theories string::ground_solver --lib`
- [x] Manual: issue #14 rows 1–5