### PR TITLE
fix(solver): polarity-aware arith diseq splits for Distinct

### DIFF
--- a/oxiz-solver/src/solver/encode.rs
+++ b/oxiz-solver/src/solver/encode.rs
@@ -1558,8 +1558,11 @@ impl Solver {
     /// This ensures the ArithSolver knows about the disequality and doesn't
     /// assign both a and b to equal values.
     pub(super) fn add_arith_diseq_split(&mut self, term: TermId, manager: &mut TermManager) {
-        let mut visited = FxHashSet::default();
-        self.add_arith_diseq_split_recursive(term, manager, &mut visited);
+        // Visit keys are (term_raw, polarity) so the same subterm under both
+        // polarities is walked correctly.
+        let mut visited: FxHashSet<(u32, bool)> = FxHashSet::default();
+        // Start under positive polarity: the assertion itself is assumed true.
+        self.add_arith_diseq_split_recursive(term, manager, &mut visited, true);
     }
 
     /// Add trichotomy clauses `Eq(a,b) OR Lt(a,b) OR Gt(a,b)` for every
@@ -1654,13 +1657,19 @@ impl Solver {
     /// This handles MBQI instantiation results that are implications like
     /// `(=> guard (not (= a b)))` where the disequality is nested inside
     /// the formula rather than at the top level.
+    /// Walk `term` under Boolean polarity `pos` (true = term occurs asserted).
+    ///
+    /// Only **positive** occurrences of arithmetic disequalities contribute
+    /// `Lt ∨ Gt` splits.  A negative Distinct (i.e. `(not (distinct …))`) means
+    /// some pair is equal — adding splits there forced unsat (issue #22).
     fn add_arith_diseq_split_recursive(
         &mut self,
         term: TermId,
         manager: &mut TermManager,
-        visited: &mut FxHashSet<TermId>,
+        visited: &mut FxHashSet<(u32, bool)>,
+        pos: bool,
     ) {
-        if !visited.insert(term) {
+        if !visited.insert((term.raw(), pos)) {
             return;
         }
 
@@ -1671,49 +1680,69 @@ impl Solver {
         match &t.kind {
             TermKind::Not(inner) => {
                 let inner_id = *inner;
-                if let Some(inner_t) = manager.get(inner_id).cloned() {
-                    if let TermKind::Eq(lhs, rhs) = &inner_t.kind {
-                        let lhs_is_numeric = manager.get(*lhs).is_some_and(|lt| {
-                            lt.sort == manager.sorts.int_sort || lt.sort == manager.sorts.real_sort
-                        });
-                        if lhs_is_numeric {
-                            let (l, r) = (*lhs, *rhs);
-                            // Build Lt(lhs, rhs) and Gt(lhs, rhs)
-                            let lt_term = manager.mk_lt(l, r);
-                            let gt_term = manager.mk_gt(l, r);
-
-                            // Encode both and add the disjunction
-                            let lt_lit = self.encode(lt_term, manager);
-                            let gt_lit = self.encode(gt_term, manager);
-                            self.sat.add_clause([lt_lit, gt_lit]);
+                // Positive Not(Eq(a,b)) is an asserted arithmetic disequality.
+                if pos {
+                    if let Some(inner_t) = manager.get(inner_id).cloned() {
+                        if let TermKind::Eq(lhs, rhs) = &inner_t.kind {
+                            let lhs_is_numeric = manager.get(*lhs).is_some_and(|lt| {
+                                lt.sort == manager.sorts.int_sort
+                                    || lt.sort == manager.sorts.real_sort
+                            });
+                            if lhs_is_numeric {
+                                let (l, r) = (*lhs, *rhs);
+                                let lt_term = manager.mk_lt(l, r);
+                                let gt_term = manager.mk_gt(l, r);
+                                let lt_lit = self.encode(lt_term, manager);
+                                let gt_lit = self.encode(gt_term, manager);
+                                self.sat.add_clause([lt_lit, gt_lit]);
+                            }
                         }
                     }
                 }
-                // Also recurse into the inner term
-                self.add_arith_diseq_split_recursive(inner_id, manager, visited);
+                self.add_arith_diseq_split_recursive(inner_id, manager, visited, !pos);
             }
             TermKind::And(args) => {
                 let args_clone: Vec<TermId> = args.iter().copied().collect();
                 for arg in args_clone {
-                    self.add_arith_diseq_split_recursive(arg, manager, visited);
+                    self.add_arith_diseq_split_recursive(arg, manager, visited, pos);
                 }
             }
             TermKind::Or(args) => {
                 let args_clone: Vec<TermId> = args.iter().copied().collect();
                 for arg in args_clone {
-                    self.add_arith_diseq_split_recursive(arg, manager, visited);
+                    self.add_arith_diseq_split_recursive(arg, manager, visited, pos);
                 }
             }
             TermKind::Implies(_, rhs) => {
-                // Recurse into the consequent -- that's where the disequality
-                // typically lives in quantifier instantiation lemmas
+                // Consequent under the same polarity as the implication when the
+                // implication is asserted (antecedent may be false — over-approx).
                 let rhs_id = *rhs;
-                self.add_arith_diseq_split_recursive(rhs_id, manager, visited);
+                self.add_arith_diseq_split_recursive(rhs_id, manager, visited, pos);
             }
             TermKind::Ite(_, then_br, else_br) => {
                 let (t, e) = (*then_br, *else_br);
-                self.add_arith_diseq_split_recursive(t, manager, visited);
-                self.add_arith_diseq_split_recursive(e, manager, visited);
+                self.add_arith_diseq_split_recursive(t, manager, visited, pos);
+                self.add_arith_diseq_split_recursive(e, manager, visited, pos);
+            }
+            TermKind::Distinct(args) if pos => {
+                // Positive Distinct: each numeric pair is disequal → Lt ∨ Gt.
+                // Negative Distinct (`not (distinct …)`) must NOT add splits:
+                // it asserts that some pair is equal (issue #22 / PR #13 bug).
+                for (i, &lhs) in args.iter().enumerate() {
+                    let lhs_is_numeric = manager.get(lhs).is_some_and(|lt| {
+                        lt.sort == manager.sorts.int_sort || lt.sort == manager.sorts.real_sort
+                    });
+                    if !lhs_is_numeric {
+                        continue;
+                    }
+                    for &rhs in args[i + 1..].iter() {
+                        let lt_term = manager.mk_lt(lhs, rhs);
+                        let gt_term = manager.mk_gt(lhs, rhs);
+                        let lt_lit = self.encode(lt_term, manager);
+                        let gt_lit = self.encode(gt_term, manager);
+                        self.sat.add_clause([lt_lit, gt_lit]);
+                    }
+                }
             }
             _ => {}
         }

--- a/oxiz-solver/tests/qf_auflia_issue22.rs
+++ b/oxiz-solver/tests/qf_auflia_issue22.rs
@@ -1,0 +1,75 @@
+//! Issue #22: `(not (distinct …))` must not force arithmetic disequality splits.
+
+use oxiz_solver::{Context, SolverResult};
+
+fn run(script: &str) -> SolverResult {
+    let mut ctx = Context::new();
+    let outputs = ctx.execute_script(script).expect("script");
+    outputs
+        .iter()
+        .rev()
+        .find_map(|l| match l.trim() {
+            "sat" => Some(SolverResult::Sat),
+            "unsat" => Some(SolverResult::Unsat),
+            "unknown" => Some(SolverResult::Unknown),
+            _ => None,
+        })
+        .unwrap_or(SolverResult::Unknown)
+}
+
+#[test]
+fn not_distinct_two_ints_is_sat() {
+    assert_eq!(
+        run(r#"
+            (set-logic QF_LIA)
+            (declare-const x Int)
+            (declare-const y Int)
+            (assert (not (distinct x y)))
+            (check-sat)
+        "#),
+        SolverResult::Sat
+    );
+}
+
+#[test]
+fn not_distinct_x_x_is_sat() {
+    assert_eq!(
+        run(r#"
+            (set-logic QF_LIA)
+            (declare-const x Int)
+            (assert (not (distinct x x)))
+            (check-sat)
+        "#),
+        SolverResult::Sat
+    );
+}
+
+#[test]
+fn positive_distinct_still_unsat_when_equal() {
+    assert_eq!(
+        run(r#"
+            (set-logic QF_LIA)
+            (declare-const x Int)
+            (assert (distinct x x))
+            (check-sat)
+        "#),
+        SolverResult::Unsat
+    );
+}
+
+#[test]
+fn arr01_read_over_write_not_distinct_is_sat() {
+    assert_eq!(
+        run(r#"
+(set-logic QF_AUFLIA)
+(declare-const a0 (Array Int Int))
+(declare-const a1 (Array Int Int))
+(declare-const i0 Int)
+(declare-const i1 Int)
+(declare-const i2 Int)
+(assert (not (distinct (select (store a1 (div 7 7) (mod (- 3) (- 5))) (+ 2 i1)) (select (store a0 (ite (<= (mod (abs 7) 2) (- 3)) (- 9) i0) (div i1 8)) (div i2 10)))))
+(check-sat)
+        "#),
+        SolverResult::Sat
+    );
+}


### PR DESCRIPTION
## Summary
- Fixes issue #22: satisfiable `(not (distinct …))` (and QF_AUFLIA read-over-write formulas using it) reported `unsat`.
- Root cause: diseq-split walk treated every `Distinct` as a **positive** disequality and added `Lt∨Gt` even under `not`, conflicting with the equality that `not (distinct a b)` requires.
- Fix: polarity-aware walk; only **positive** `Distinct` / `not (= …)` emit arithmetic splits.
- Also covers the intent of #13 (Distinct → arith diseq) without the false-unsat bug.

Closes #22
Related: #12, #13

## Test plan
- [x] `cargo test -p oxiz-solver --test qf_auflia_issue22`
- [x] `(not (distinct x y))` → sat
- [x] `(distinct x x)` → unsat
- [x] issue #22 array formula → sat (matches z3)